### PR TITLE
Wire NextAuth auth flow and scaffold authenticated dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ npm run dev
 
 Then open [http://localhost:3000](http://localhost:3000) to explore the marketing shell and navigate to `/login` for the authentication experience.
 
+### Authentication
+
+PaceTrace now ships with demo credentials wired through a NextAuth credentials provider. Sign in at `/login` with:
+
+```
+Email: driver@pacetrace.app
+Password: pitlane
+```
+
+Override the defaults by setting `AUTH_DEMO_EMAIL` and `AUTH_DEMO_PASSWORD` in your environment. Provide a `NEXTAUTH_SECRET` when deploying to production.
+
 ## Available scripts
 
 | Script | Description |
@@ -27,16 +38,16 @@ Then open [http://localhost:3000](http://localhost:3000) to explore the marketin
 ```
 src/
   app/
+    (app)/          # Authenticated routes and layout
+    api/auth/       # NextAuth handler
     layout.tsx      # Global font loading and metadata
+    login/          # Sign-in screen + client form logic
     page.tsx        # Landing page scaffold
-    login/page.tsx  # Sign-in screen
   app/globals.css   # Tailwind + design tokens
 ```
 
 Tailwind is configured with semantic tokens (background, card, accent, etc.) to make it easy to extend the design system as authenticated surfaces come online. The login form includes analytics-friendly attributes so future telemetry hooks can be wired without redesigning the UI.
 
-## Next steps
+## Observability hooks
 
-- Wire the sign-in form to your auth provider (Clerk, NextAuth, etc.).
-- Build the authenticated dashboard routes under `src/app/(app)`.
-- Layer in telemetry + logging plumbing as the backend stabilizes.
+Structured logging and telemetry helpers live in `src/lib/logging.ts` and `src/lib/telemetry.ts`. The authentication flow, protected layouts, and dashboard surfaces publish events so backend services can ingest them as the platform matures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "14.2.5",
+        "next-auth": "^4.24.11",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -34,6 +35,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -476,6 +486,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1561,6 +1580,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3519,6 +3547,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3871,6 +3908,38 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -3908,6 +3977,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4042,6 +4117,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4050,6 +4134,42 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -4366,6 +4486,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4375,6 +4517,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5624,6 +5772,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5845,6 +6002,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.2.5",
+    "next-auth": "^4.24.11",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.2.5"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.5",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.5"
+    "typescript": "^5"
   }
 }

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+
+import { getLogger } from "@/lib/logging";
+import { trackEvent } from "@/lib/telemetry";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description: "Live health of race programs, imports, and crew readiness.",
+};
+
+const mockMetrics = [
+  {
+    label: "Active heats",
+    value: 6,
+    change: "+2 vs last round",
+  },
+  {
+    label: "Telemetry uptime",
+    value: "99.7%",
+    change: "+0.4%",
+  },
+  {
+    label: "Crew callouts",
+    value: 32,
+    change: "8 acknowledged",
+  },
+];
+
+export default function DashboardPage() {
+  getLogger().info("dashboard.viewed");
+  trackEvent("dashboard.render");
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-2">
+        <h1 className="text-3xl font-semibold">Race control overview</h1>
+        <p className="text-sm text-muted-foreground">
+          Keep tabs on laps, alerts, and coaching notes from practice through mains.
+        </p>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {mockMetrics.map((metric) => (
+          <article
+            key={metric.label}
+            className="rounded-2xl border border-border/70 bg-background/80 p-5 shadow-card"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground/70">
+              {metric.label}
+            </p>
+            <p className="mt-3 text-3xl font-semibold text-foreground">{metric.value}</p>
+            <p className="text-xs text-muted-foreground/80">{metric.change}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[2fr_3fr]">
+        <div className="rounded-2xl border border-border/70 bg-background/80 p-5">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+            Import backlog
+          </h2>
+          <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
+            {["LiveRC", "Manual telemetry", "Coaching notes"].map((queue) => (
+              <li key={queue} className="flex items-center justify-between rounded-xl border border-border/60 bg-card/70 px-4 py-3">
+                <span>{queue}</span>
+                <span className="text-xs uppercase tracking-[0.24em] text-accent">Healthy</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="rounded-2xl border border-border/70 bg-background/80 p-5">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+            Crew radar
+          </h2>
+          <div className="mt-4 space-y-4">
+            {["Pit lane", "Spotter deck", "Data review"].map((station) => (
+              <div key={station} className="rounded-xl border border-border/60 bg-card/70 p-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground/70">{station}</p>
+                <p className="mt-2 text-sm text-foreground">
+                  All clear. No escalations in the last 15 minutes.
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+
+import { SignOutButton } from "@/components/sign-out-button";
+
+export default async function AppLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/40">
+      <header className="border-b border-border/50 bg-background/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex size-9 items-center justify-center rounded-full border border-border/60 bg-card/60 text-sm font-semibold uppercase tracking-[0.24em] text-accent">
+              PT
+            </span>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-foreground">PaceTrace Ops</p>
+              <p className="text-xs text-muted-foreground/80">
+                {session.user.email}
+              </p>
+            </div>
+          </div>
+          <nav className="flex items-center gap-3 text-sm font-medium text-muted-foreground">
+            <Link className="rounded-full border border-transparent px-3 py-1.5 transition hover:border-border/80 hover:text-foreground" href="/dashboard">
+              Dashboard
+            </Link>
+            <Link className="rounded-full border border-transparent px-3 py-1.5 transition hover:border-border/80 hover:text-foreground" href="/timeline">
+              Timeline
+            </Link>
+            <Link className="rounded-full border border-transparent px-3 py-1.5 transition hover:border-border/80 hover:text-foreground" href="/ops">
+              Operations
+            </Link>
+          </nav>
+          <SignOutButton email={session.user.email ?? ""} />
+        </div>
+      </header>
+      <main className="mx-auto flex min-h-[calc(100vh-4.5rem)] w-full max-w-6xl flex-col gap-8 px-6 py-10">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/(app)/ops/page.tsx
+++ b/src/app/(app)/ops/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+
+import { getLogger } from "@/lib/logging";
+import { trackEvent } from "@/lib/telemetry";
+
+export const metadata: Metadata = {
+  title: "Operations",
+  description: "Operational readiness, health checks, and service-level instrumentation.",
+};
+
+const checks = [
+  {
+    title: "Ingest service",
+    description: "Webhooks processed under 300ms with no retries in the last hour.",
+    status: "operational",
+  },
+  {
+    title: "Telemetry fanout",
+    description: "Callouts delivered to 12 pit tablets. Zero drops detected.",
+    status: "operational",
+  },
+  {
+    title: "Audit ledger",
+    description: "Writes delayed. Queuing new spans for replay.",
+    status: "degraded",
+  },
+];
+
+const statusStyles: Record<"operational" | "degraded" | "outage", string> = {
+  operational: "bg-success/15 text-success border-success/40",
+  degraded: "bg-warning/15 text-warning border-warning/40",
+  outage: "bg-destructive/15 text-destructive border-destructive/40",
+};
+
+export default function OpsPage() {
+  getLogger().info("ops.viewed");
+  trackEvent("ops.render");
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Operational readiness</h1>
+        <p className="text-sm text-muted-foreground">
+          Instrumented health checks and structured logs keep the pit wall confident.
+        </p>
+      </header>
+      <div className="grid gap-4 lg:grid-cols-2">
+        {checks.map((check) => (
+          <article
+            key={check.title}
+            className="rounded-2xl border border-border/70 bg-background/80 p-5 shadow-card"
+          >
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-foreground">{check.title}</h2>
+              <span
+                className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] ${statusStyles[check.status]}`}
+              >
+                {check.status}
+              </span>
+            </div>
+            <p className="mt-3 text-sm text-muted-foreground">{check.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/timeline/page.tsx
+++ b/src/app/(app)/timeline/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from "next";
+
+import { withRequestLogger } from "@/lib/logging";
+import { trackEvent } from "@/lib/telemetry";
+
+export const metadata: Metadata = {
+  title: "Timeline",
+  description: "Telemetry, pit notes, and incidents sequenced for rapid reviews.",
+};
+
+const events = [
+  {
+    id: "lap-18",
+    label: "Lap 18",
+    message: "Driver clipped the apex; pit requested tighter line next lap.",
+    severity: "medium" as const,
+  },
+  {
+    id: "lap-19",
+    label: "Lap 19",
+    message: "Fast lap triggered. Broadcasting callout to tablets.",
+    severity: "low" as const,
+  },
+  {
+    id: "lap-20",
+    label: "Lap 20",
+    message: "Telemetry packet loss detected on sector three sensor.",
+    severity: "high" as const,
+  },
+];
+
+const severityStyles: Record<typeof events[number]["severity"], string> = {
+  low: "bg-success/20 text-success border-success/40",
+  medium: "bg-warning/10 text-warning border-warning/40",
+  high: "bg-destructive/10 text-destructive border-destructive/40",
+};
+
+export default function TimelinePage() {
+  const logger = withRequestLogger({ route: "timeline" });
+  logger.info("timeline.viewed");
+  trackEvent("timeline.render");
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Session timeline</h1>
+        <p className="text-sm text-muted-foreground">
+          Cross-reference telemetry spikes with pit callouts to coach smarter.
+        </p>
+      </header>
+      <ol className="space-y-4">
+        {events.map((event) => (
+          <li key={event.id} className="rounded-2xl border border-border/60 bg-background/80 p-5 shadow-card">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground/80">
+                {event.label}
+              </span>
+              <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.28em] ${severityStyles[event.severity]}`}>
+                {event.severity}
+              </span>
+            </div>
+            <p className="mt-3 text-sm text-foreground">{event.message}</p>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { LoginForm } from "./sign-in-form";
+
 export const metadata: Metadata = {
   title: "Sign in",
   description: "Authenticate to access PaceTrace telemetry and coaching tools.",
@@ -25,68 +27,25 @@ export default function LoginPage() {
         </div>
 
         <div className="rounded-3xl border border-border/60 bg-card/80 p-8 shadow-card backdrop-blur-xl">
-          <form className="space-y-6" method="post" data-analytics-event="auth:submit">
-            <div className="grid gap-2 text-left">
-              <label className="text-sm font-medium text-foreground/80" htmlFor="email">
-                Email address
-              </label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
-                placeholder="you@teamradio.com"
-              />
-            </div>
+          <LoginForm />
+        </div>
 
-            <div className="grid gap-2 text-left">
-              <div className="flex items-center justify-between">
-                <label className="text-sm font-medium text-foreground/80" htmlFor="password">
-                  Password
-                </label>
-                <Link className="text-xs font-medium text-accent hover:text-[hsl(var(--color-accent-muted))]" href="#">
-                  Forgot password?
-                </Link>
-              </div>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                required
-                className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
-                placeholder="••••••••"
-              />
-            </div>
-
-            <button
-              type="submit"
-              className="inline-flex w-full items-center justify-center rounded-lg bg-accent px-4 py-3 text-base font-semibold text-background transition hover:bg-[hsl(var(--color-accent-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-              data-analytics-event="auth:submit:primary"
-            >
-              Sign in
-            </button>
-          </form>
-
-          <div className="mt-8 space-y-3 text-left text-xs text-muted-foreground">
-            <p className="font-semibold uppercase tracking-[0.3em] text-muted-foreground/70">What you get</p>
-            <ul className="space-y-2">
-              <li className="flex items-start gap-2">
-                <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
-                Live lap comparisons across heats and mains
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
-                Telemetry callouts delivered to pit tablets
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
-                Secure multi-tenant workspace for your crew
-              </li>
-            </ul>
-          </div>
+        <div className="mt-8 space-y-3 text-left text-xs text-muted-foreground">
+          <p className="font-semibold uppercase tracking-[0.3em] text-muted-foreground/70">What you get</p>
+          <ul className="space-y-2">
+            <li className="flex items-start gap-2">
+              <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
+              Live lap comparisons across heats and mains
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
+              Telemetry callouts delivered to pit tablets
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
+              Secure multi-tenant workspace for your crew
+            </li>
+          </ul>
         </div>
 
         <p className="text-center text-xs text-muted-foreground">

--- a/src/app/login/sign-in-form.tsx
+++ b/src/app/login/sign-in-form.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { signIn } from "next-auth/react";
+import { useState, type FormEvent } from "react";
+
+import { trackUiEvent } from "@/lib/telemetry";
+
+export function LoginForm() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const email = (formData.get("email") as string | null)?.trim();
+    const password = formData.get("password") as string | null;
+
+    trackUiEvent("auth.submit", { email });
+
+    const result = await signIn("credentials", {
+      redirect: false,
+      email,
+      password,
+      callbackUrl: "/dashboard",
+    });
+
+    if (result?.error) {
+      setError("We couldn't verify those credentials. Give it another lap.");
+      trackUiEvent("auth.error", { email, code: result.error });
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (result?.url) {
+      trackUiEvent("auth.success", { email });
+      router.push(result.url);
+      router.refresh();
+      form.reset();
+    } else {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" method="post" data-analytics-event="auth:submit" onSubmit={handleSubmit}>
+      <div className="grid gap-2 text-left">
+        <label className="text-sm font-medium text-foreground/80" htmlFor="email">
+          Email address
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
+          placeholder="you@teamradio.com"
+        />
+      </div>
+
+      <div className="grid gap-2 text-left">
+        <div className="flex items-center justify-between">
+          <label className="text-sm font-medium text-foreground/80" htmlFor="password">
+            Password
+          </label>
+          <span className="text-xs font-medium text-accent">Contact ops</span>
+        </div>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          required
+          className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
+          placeholder="••••••••"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="inline-flex w-full items-center justify-center rounded-lg bg-accent px-4 py-3 text-base font-semibold text-background transition hover:bg-[hsl(var(--color-accent-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-70"
+        data-analytics-event="auth:submit:primary"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "Signing in..." : "Sign in"}
+      </button>
+      {error ? (
+        <p className="text-sm font-medium text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,117 @@
+import NextAuth, { type NextAuthConfig } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+
+import { getLogger } from "@/lib/logging";
+import { trackAuthEvent } from "@/lib/telemetry";
+
+const demoEmail = process.env.AUTH_DEMO_EMAIL ?? "driver@pacetrace.app";
+const demoPassword = process.env.AUTH_DEMO_PASSWORD ?? "pitlane";
+
+const config: NextAuthConfig = {
+  providers: [
+    Credentials({
+      name: "Email",
+      credentials: {
+        email: { label: "Email", type: "email", placeholder: demoEmail },
+        password: { label: "Password", type: "password" },
+      },
+      authorize: async (credentials) => {
+        const logger = getLogger();
+        logger.info("auth.credentials.attempt", {
+          email: credentials?.email,
+        });
+
+        if (!credentials?.email || !credentials.password) {
+          logger.warn("auth.credentials.missing", {
+            hasEmail: Boolean(credentials?.email),
+            hasPassword: Boolean(credentials?.password),
+          });
+          return null;
+        }
+
+        const normalizedEmail = credentials.email.trim().toLowerCase();
+        const password = credentials.password;
+
+        if (normalizedEmail === demoEmail && password === demoPassword) {
+          const user = {
+            id: "demo-user",
+            email: normalizedEmail,
+            name: "Race Strategist",
+            role: "owner" as const,
+          };
+
+          trackAuthEvent("credentials.success", {
+            email: normalizedEmail,
+          });
+
+          logger.info("auth.credentials.success", {
+            email: normalizedEmail,
+          });
+
+          return user;
+        }
+
+        trackAuthEvent("credentials.failure", {
+          email: normalizedEmail,
+        });
+
+        logger.warn("auth.credentials.invalid", {
+          email: normalizedEmail,
+        });
+
+        return null;
+      },
+    }),
+  ],
+  pages: {
+    signIn: "/login",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as { role?: string }).role ?? "member";
+      }
+
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.sub ?? "demo-user";
+        session.user.role = (token.role as string | undefined) ?? "member";
+      }
+
+      return session;
+    },
+  },
+  logger: {
+    error: (code, metadata) => {
+      getLogger().error("auth.error", { code, metadata });
+    },
+    warn: (code) => {
+      getLogger().warn("auth.warn", { code });
+    },
+    debug: (code, metadata) => {
+      if (process.env.NODE_ENV !== "production") {
+        getLogger().debug("auth.debug", { code, metadata });
+      }
+    },
+  },
+  events: {
+    async signIn(message) {
+      trackAuthEvent("signIn", {
+        userId: message.user.id,
+        provider: message.account?.provider,
+      });
+    },
+    async signOut(message) {
+      trackAuthEvent("signOut", {
+        userId: message.token?.sub,
+      });
+    },
+  },
+};
+
+export const { handlers, auth, signIn, signOut } = NextAuth(config);

--- a/src/components/sign-out-button.tsx
+++ b/src/components/sign-out-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+
+import { trackUiEvent } from "@/lib/telemetry";
+
+type Props = {
+  email: string;
+};
+
+export function SignOutButton({ email }: Props) {
+  const handleSignOut = async () => {
+    trackUiEvent("auth.signOut", { email });
+    await signOut({ callbackUrl: "/login" });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleSignOut}
+      className="inline-flex items-center justify-center rounded-full border border-border/70 bg-card/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground transition hover:border-accent/60 hover:text-accent"
+    >
+      Sign out
+    </button>
+  );
+}

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,0 +1,84 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+type LogEntry = {
+  level: LogLevel;
+  message: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+};
+
+const GLOBAL_KEY = "__PACE_TRACE_LOGGER__";
+
+class Logger {
+  private baseFields: Record<string, unknown>;
+
+  constructor(baseFields: Record<string, unknown> = {}) {
+    this.baseFields = baseFields;
+  }
+
+  child(fields: Record<string, unknown>) {
+    return new Logger({ ...this.baseFields, ...fields });
+  }
+
+  debug(message: string, metadata?: Record<string, unknown>) {
+    this.log("debug", message, metadata);
+  }
+
+  info(message: string, metadata?: Record<string, unknown>) {
+    this.log("info", message, metadata);
+  }
+
+  warn(message: string, metadata?: Record<string, unknown>) {
+    this.log("warn", message, metadata);
+  }
+
+  error(message: string, metadata?: Record<string, unknown>) {
+    this.log("error", message, metadata);
+  }
+
+  private log(level: LogLevel, message: string, metadata?: Record<string, unknown>) {
+    const entry: LogEntry = {
+      level,
+      message,
+      timestamp: new Date().toISOString(),
+      metadata: metadata ? { ...this.baseFields, ...metadata } : this.baseFields,
+    };
+
+    const line = JSON.stringify(entry);
+
+    switch (level) {
+      case "debug":
+        if (process.env.NODE_ENV !== "production") {
+          console.debug(line);
+        }
+        break;
+      case "info":
+        console.info(line);
+        break;
+      case "warn":
+        console.warn(line);
+        break;
+      case "error":
+        console.error(line);
+        break;
+      default:
+        console.log(line);
+    }
+  }
+}
+
+export function getLogger() {
+  const globalScope = globalThis as typeof globalThis & {
+    [GLOBAL_KEY]?: Logger;
+  };
+
+  if (!globalScope[GLOBAL_KEY]) {
+    globalScope[GLOBAL_KEY] = new Logger({ service: "pace-trace" });
+  }
+
+  return globalScope[GLOBAL_KEY];
+}
+
+export function withRequestLogger(context: Record<string, unknown>) {
+  return getLogger().child(context);
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,39 @@
+import { getLogger } from "./logging";
+
+type TelemetryPayload = Record<string, unknown>;
+
+function getBuffer() {
+  const globalScope = globalThis as typeof globalThis & {
+    __PACE_TRACE_TELEMETRY__?: TelemetryPayload[];
+  };
+
+  if (!globalScope.__PACE_TRACE_TELEMETRY__) {
+    globalScope.__PACE_TRACE_TELEMETRY__ = [];
+  }
+
+  return globalScope.__PACE_TRACE_TELEMETRY__;
+}
+
+export function trackEvent(event: string, payload: TelemetryPayload = {}) {
+  const enriched = {
+    event,
+    ...payload,
+    timestamp: new Date().toISOString(),
+  } satisfies TelemetryPayload;
+
+  getBuffer().push(enriched);
+  getLogger().info("telemetry.event", enriched);
+}
+
+export function flushEvents() {
+  const buffer = getBuffer();
+  buffer.length = 0;
+}
+
+export function trackAuthEvent(event: string, payload: TelemetryPayload = {}) {
+  trackEvent(`auth.${event}`, payload);
+}
+
+export function trackUiEvent(event: string, payload: TelemetryPayload = {}) {
+  trackEvent(`ui.${event}`, payload);
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,20 @@
+import { type DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultSession["user"] & {
+      id: string;
+      role: string;
+    };
+  }
+
+  interface User {
+    role?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth credentials provider with telemetry-aware logging and expose auth helpers
- convert the sign-in page to use a client form wired to the provider and document demo credentials
- add protected dashboard, timeline, and operations routes with shared layout and observability plumbing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ac6438ac8321ac58e9649e2ff6f0