### PR TITLE
Revamp login page to mirror Spotify experience

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,47 +10,28 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <div className="relative isolate flex min-h-screen items-center justify-center px-4 py-16 sm:px-6">
+    <div className="relative isolate flex min-h-screen items-center justify-center overflow-hidden bg-[#121212] px-4 py-16 text-white sm:px-6">
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,hsla(var(--color-accent)/0.35),transparent_70%)]"
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,hsla(var(--color-accent)/0.35),transparent_65%)]"
       />
-      <div className="w-full max-w-md space-y-10">
-        <div className="space-y-3 text-center">
-          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-            PaceTrace
-          </p>
-          <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">Welcome back</h1>
-          <p className="text-sm text-muted-foreground">
-            Sign in to review lap deltas, annotate heats, and keep your team aligned on race-day decisions.
-          </p>
-        </div>
+      <div className="absolute inset-x-0 top-0 -z-10 h-1/2 bg-[radial-gradient(circle_at_top,hsl(var(--color-accent)/0.2),transparent_70%)]" aria-hidden />
+      <div className="relative w-full max-w-lg">
+        <div className="space-y-8 rounded-[32px] bg-white/5 p-10 text-white shadow-[0_30px_80px_-40px_rgba(0,0,0,0.8)] ring-1 ring-white/10 backdrop-blur-xl">
+          <div className="space-y-4 text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">PaceTrace</p>
+            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">Log in to keep the pace</h1>
+            <p className="text-sm text-white/70">
+              Pick the quickest route back into telemetry insights and team coordination.
+            </p>
+          </div>
 
-        <div className="rounded-3xl border border-border/60 bg-card/80 p-8 shadow-card backdrop-blur-xl">
           <LoginForm />
         </div>
 
-        <div className="mt-8 space-y-3 text-left text-xs text-muted-foreground">
-          <p className="font-semibold uppercase tracking-[0.3em] text-muted-foreground/70">What you get</p>
-          <ul className="space-y-2">
-            <li className="flex items-start gap-2">
-              <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
-              Live lap comparisons across heats and mains
-            </li>
-            <li className="flex items-start gap-2">
-              <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
-              Telemetry callouts delivered to pit tablets
-            </li>
-            <li className="flex items-start gap-2">
-              <span className="mt-1 size-1.5 rounded-full bg-success" aria-hidden />
-              Secure multi-tenant workspace for your crew
-            </li>
-          </ul>
-        </div>
-
-        <p className="text-center text-xs text-muted-foreground">
-          New to PaceTrace?{" "}
-          <Link className="font-medium text-foreground hover:text-accent" href="#">
+        <p className="mt-8 text-center text-xs text-white/60">
+          Need an invite?{" "}
+          <Link className="font-medium text-white transition hover:text-[hsl(var(--color-accent))]" href="#">
             Request early access
           </Link>
         </p>

--- a/src/app/login/sign-in-form.tsx
+++ b/src/app/login/sign-in-form.tsx
@@ -2,14 +2,27 @@
 
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { useState, type FormEvent } from "react";
+import { Fragment, useState, type FormEvent } from "react";
 
 import { trackUiEvent } from "@/lib/telemetry";
 
 export function LoginForm() {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isProviderSubmitting, setIsProviderSubmitting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const handleProviderSignIn = async (provider: string) => {
+    setError(null);
+    setIsProviderSubmitting(provider);
+    trackUiEvent("auth.provider", { provider });
+
+    try {
+      await signIn(provider, { callbackUrl: "/dashboard" });
+    } finally {
+      setIsProviderSubmitting(null);
+    }
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -48,13 +61,59 @@ export function LoginForm() {
   };
 
   return (
-    <form className="space-y-6" method="post" data-analytics-event="auth:submit" onSubmit={handleSubmit}>
-      <div className="grid gap-2 text-left">
-        <label className="text-sm font-medium text-foreground/80" htmlFor="email">
-          Email address
-        </label>
-        <input
-          id="email"
+    <Fragment>
+      <div className="space-y-3">
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#121212] transition hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+          data-analytics-event="auth:provider:google"
+          disabled={Boolean(isProviderSubmitting)}
+          onClick={() => void handleProviderSignIn("google")}
+        >
+          {isProviderSubmitting === "google" ? "Connecting to Google…" : "Continue with Google"}
+        </button>
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center rounded-full border border-white/40 bg-transparent px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+          data-analytics-event="auth:provider:facebook"
+          disabled={Boolean(isProviderSubmitting)}
+          onClick={() => void handleProviderSignIn("facebook")}
+        >
+          {isProviderSubmitting === "facebook" ? "Connecting to Facebook…" : "Continue with Facebook"}
+        </button>
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center rounded-full border border-white/40 bg-transparent px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+          data-analytics-event="auth:provider:apple"
+          disabled={Boolean(isProviderSubmitting)}
+          onClick={() => void handleProviderSignIn("apple")}
+        >
+          {isProviderSubmitting === "apple" ? "Connecting to Apple…" : "Continue with Apple"}
+        </button>
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center rounded-full border border-white/40 bg-transparent px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+          data-analytics-event="auth:provider:phone"
+          disabled={Boolean(isProviderSubmitting)}
+          onClick={() => void handleProviderSignIn("phone")}
+        >
+          {isProviderSubmitting === "phone" ? "Texting your phone…" : "Continue with phone number"}
+        </button>
+      </div>
+
+      <div className="flex items-center gap-4 text-xs uppercase tracking-[0.3em] text-white/40">
+        <span className="h-px flex-1 bg-white/20" aria-hidden />
+        Or
+        <span className="h-px flex-1 bg-white/20" aria-hidden />
+      </div>
+
+      <form className="space-y-6" method="post" data-analytics-event="auth:submit" onSubmit={handleSubmit}>
+        <div className="grid gap-2 text-left">
+          <label className="text-sm font-medium text-foreground/80" htmlFor="email">
+            Email address
+          </label>
+          <input
+            id="email"
           name="email"
           type="email"
           autoComplete="email"
@@ -62,39 +121,40 @@ export function LoginForm() {
           className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
           placeholder="you@teamradio.com"
         />
-      </div>
-
-      <div className="grid gap-2 text-left">
-        <div className="flex items-center justify-between">
-          <label className="text-sm font-medium text-foreground/80" htmlFor="password">
-            Password
-          </label>
-          <span className="text-xs font-medium text-accent">Contact ops</span>
         </div>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          autoComplete="current-password"
-          required
-          className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
-          placeholder="••••••••"
-        />
-      </div>
 
-      <button
-        type="submit"
-        className="inline-flex w-full items-center justify-center rounded-lg bg-accent px-4 py-3 text-base font-semibold text-background transition hover:bg-[hsl(var(--color-accent-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-70"
-        data-analytics-event="auth:submit:primary"
-        disabled={isSubmitting}
-      >
-        {isSubmitting ? "Signing in..." : "Sign in"}
-      </button>
-      {error ? (
-        <p className="text-sm font-medium text-destructive" role="alert">
-          {error}
-        </p>
-      ) : null}
-    </form>
+        <div className="grid gap-2 text-left">
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium text-foreground/80" htmlFor="password">
+              Password
+            </label>
+            <span className="text-xs font-medium text-accent">Contact ops</span>
+          </div>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
+            placeholder="••••••••"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="inline-flex w-full items-center justify-center rounded-full bg-[hsl(var(--color-accent))] px-6 py-3 text-sm font-semibold text-[#0f0f0f] transition hover:bg-[hsl(var(--color-accent-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:cursor-not-allowed disabled:opacity-70"
+          data-analytics-event="auth:submit:primary"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Signing in…" : "Sign in"}
+        </button>
+        {error ? (
+          <p className="text-sm font-medium text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </form>
+    </Fragment>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the login screen with a centered dark card treatment inspired by Spotify's layout
- add quick sign-in buttons for Google, Facebook, Apple, and phone flows alongside the existing email form
- preserve telemetry hooks while updating button states for alternate providers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b168abc48321a855b88553bbc6a2