### PR TITLE
Fix NextAuth handler exports

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,3 @@
-import { handlers } from "@/auth";
+import { authHandler } from "@/auth";
 
-export const { GET, POST } = handlers;
+export { authHandler as GET, authHandler as POST };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,4 @@
-import NextAuth, { type NextAuthConfig } from "next-auth";
+import NextAuth, { type NextAuthOptions, getServerSession } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 
 import { getLogger } from "@/lib/logging";
@@ -7,7 +7,7 @@ import { trackAuthEvent } from "@/lib/telemetry";
 const demoEmail = process.env.AUTH_DEMO_EMAIL ?? "driver@pacetrace.app";
 const demoPassword = process.env.AUTH_DEMO_PASSWORD ?? "pitlane";
 
-const config: NextAuthConfig = {
+export const authOptions: NextAuthOptions = {
   providers: [
     Credentials({
       name: "Email",
@@ -114,4 +114,6 @@ const config: NextAuthConfig = {
   },
 };
 
-export const { handlers, auth, signIn, signOut } = NextAuth(config);
+export const auth = () => getServerSession(authOptions);
+
+export const authHandler = NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- update the shared NextAuth configuration to export explicit auth options and a server-side session helper
- replace the broken handler destructuring with a single NextAuth handler that can be re-used by the route module
- expose the handler via the API route so Google sign-in and other providers work again

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c029107c8321ad3f6ad17616ecd5