### PR TITLE
feat: rebuild login screen

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,18 +4,19 @@
 
 @layer base {
   :root {
-    --color-bg: 228 60% 8%;
-    --color-fg: 215 33% 92%;
-    --color-muted: 226 34% 16%;
-    --color-muted-foreground: 217 19% 68%;
-    --color-card: 229 47% 12%;
-    --color-card-border: 227 38% 23%;
-    --color-accent: 267 84% 68%;
-    --color-accent-muted: 268 74% 60%;
-    --color-success: 160 84% 39%;
-    --color-destructive: 0 84% 63%;
+    --color-bg: 213 56% 96%;
+    --color-fg: 214 76% 12%;
+    --color-muted: 213 38% 91%;
+    --color-muted-foreground: 217 22% 46%;
+    --color-card: 0 0% 100%;
+    --color-card-border: 215 33% 86%;
+    --color-accent: 208 84% 40%;
+    --color-accent-muted: 208 80% 48%;
+    --color-accent-2: 164 98% 52%;
+    --color-success: 164 98% 40%;
+    --color-destructive: 4 74% 49%;
 
-    color-scheme: dark;
+    color-scheme: light;
   }
 
   * {
@@ -26,13 +27,13 @@
     @apply min-h-screen bg-background text-foreground antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
     background-image:
-      radial-gradient(circle at 20% -10%, hsla(var(--color-accent) / 0.22), transparent 55%),
-      radial-gradient(circle at 80% 0%, hsla(var(--color-accent) / 0.14), transparent 50%),
-      linear-gradient(180deg, hsla(var(--color-bg) / 1) 0%, hsla(var(--color-bg) / 1) 100%);
+      radial-gradient(circle at 12% -10%, hsla(var(--color-accent) / 0.25), transparent 55%),
+      radial-gradient(circle at 88% -20%, hsla(var(--color-accent-2) / 0.22), transparent 60%),
+      linear-gradient(180deg, hsl(var(--color-bg)) 0%, hsl(var(--color-bg)) 100%);
   }
 
   a {
-    @apply text-foreground underline-offset-4 transition-colors hover:text-accent;
+    @apply text-accent underline-offset-4 transition-colors hover:text-accent-muted;
   }
 }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,32 +10,57 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <div className="relative isolate flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-16 text-foreground sm:px-6">
+    <div className="relative flex min-h-screen flex-col bg-background text-foreground">
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,hsla(var(--color-accent)/0.35),transparent_65%)]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,hsla(var(--color-accent)/0.2),transparent_60%)]"
       />
-      <div className="absolute inset-x-0 top-0 -z-10 h-1/2 bg-[radial-gradient(circle_at_top,hsl(var(--color-accent)/0.2),transparent_70%)]" aria-hidden />
-      <div className="relative w-full max-w-lg">
-        <div className="space-y-8 rounded-[32px] bg-[hsla(var(--color-card)/0.88)] p-10 text-foreground shadow-[0_30px_80px_-40px_hsla(var(--color-accent)/0.6)] ring-1 ring-[hsla(var(--color-card-border)/0.6)] backdrop-blur-xl">
-          <div className="space-y-4 text-center">
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-foreground/70">PaceTrace</p>
-            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">Log in to keep the pace</h1>
-            <p className="text-sm text-foreground/70">
-              Pick the quickest route back into telemetry insights and team coordination.
-            </p>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-[-10%] h-[420px] bg-[radial-gradient(circle_at_top_right,hsla(var(--color-accent-2)/0.25),transparent_65%)]"
+      />
+
+      <header className="relative z-10 mx-auto w-full max-w-4xl px-4 pt-12 text-center sm:px-6">
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+          PaceTrace — the one-stop lap logic shop.
+        </p>
+      </header>
+
+      <main className="relative z-10 flex flex-1 items-center justify-center px-4 pb-16 pt-8 sm:px-6">
+        <section className="w-full max-w-xl">
+          <div className="overflow-hidden rounded-[32px] border border-border/70 bg-card/95 shadow-card backdrop-blur-sm">
+            <div className="space-y-10 p-10 sm:p-12">
+              <div className="space-y-3 text-center">
+                <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Sign in</h1>
+                <p className="text-base text-muted-foreground">Access your PaceTrace data.</p>
+              </div>
+
+              <LoginForm />
+            </div>
           </div>
 
-          <LoginForm />
-        </div>
+          <p className="mt-6 text-center text-sm text-muted-foreground">
+            Need an account?{" "}
+            <Link className="font-semibold text-accent transition hover:text-accent-muted" href="/register">
+              Create one
+            </Link>
+          </p>
+        </section>
+      </main>
 
-        <p className="mt-8 text-center text-xs text-foreground/60">
-          Need an invite?{" "}
-          <Link className="font-medium text-foreground transition hover:text-[hsl(var(--color-accent))]" href="#">
-            Request early access
-          </Link>
+      <footer className="relative z-10 border-t border-border/60 bg-card/70 py-8 backdrop-blur-sm">
+        <p className="mx-auto max-w-4xl px-4 text-center text-xs text-muted-foreground sm:px-6">
+          © PaceTrace •{" "}
+          <Link className="font-medium text-accent transition hover:text-accent-muted" href="/legal/privacy">
+            Privacy
+          </Link>{" "}
+          •{" "}
+          <Link className="font-medium text-accent transition hover:text-accent-muted" href="/legal/terms">
+            Terms
+          </Link>{" "}
+          • <span className="font-semibold text-foreground">See the data. Find the pace.</span>
         </p>
-      </div>
+      </footer>
     </div>
   );
 }

--- a/src/app/login/sign-in-form.tsx
+++ b/src/app/login/sign-in-form.tsx
@@ -1,18 +1,37 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { signIn } from "next-auth/react";
-import { Fragment, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Fragment, useMemo, useState, type FormEvent } from "react";
 
 import { trackUiEvent } from "@/lib/telemetry";
+
+const providerCopy: Record<string, { label: string; busy: string }> = {
+  google: {
+    label: "Continue with Google",
+    busy: "Connecting to Google…",
+  },
+  apple: {
+    label: "Continue with Apple",
+    busy: "Connecting to Apple…",
+  },
+  facebook: {
+    label: "Continue with Facebook",
+    busy: "Connecting to Facebook…",
+  },
+};
 
 export function LoginForm() {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isProviderSubmitting, setIsProviderSubmitting] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const handleProviderSignIn = async (provider: string) => {
-    setError(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
+  const isBusy = useMemo(() => isSubmitting || Boolean(isProviderSubmitting), [isSubmitting, isProviderSubmitting]);
+
+  const handleProviderSignIn = async (provider: "google" | "apple" | "facebook") => {
+    setPasswordError(null);
     setIsProviderSubmitting(provider);
     trackUiEvent("auth.provider", { provider });
 
@@ -25,15 +44,16 @@ export function LoginForm() {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setError(null);
+    setPasswordError(null);
     setIsSubmitting(true);
 
     const form = event.currentTarget;
     const formData = new FormData(form);
     const email = (formData.get("email") as string | null)?.trim();
-    const password = formData.get("password") as string | null;
+    const password = (formData.get("password") as string | null) ?? "";
+    const remember = formData.get("remember") === "on";
 
-    trackUiEvent("auth.submit", { email });
+    trackUiEvent("auth.submit", { email, remember });
 
     const result = await signIn("credentials", {
       redirect: false,
@@ -43,7 +63,7 @@ export function LoginForm() {
     });
 
     if (result?.error) {
-      setError("We couldn't verify those credentials. Give it another lap.");
+      setPasswordError("We couldn't verify those credentials. Give it another lap.");
       trackUiEvent("auth.error", { email, code: result.error });
       setIsSubmitting(false);
       return;
@@ -61,54 +81,9 @@ export function LoginForm() {
 
   return (
     <Fragment>
-      <div className="space-y-3">
-        <button
-          type="button"
-          className="inline-flex w-full items-center justify-center rounded-full bg-foreground px-6 py-3 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsla(var(--color-foreground)/0.55)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))]"
-          data-analytics-event="auth:provider:google"
-          disabled={Boolean(isProviderSubmitting)}
-          onClick={() => void handleProviderSignIn("google")}
-        >
-          {isProviderSubmitting === "google" ? "Connecting to Google…" : "Continue with Google"}
-        </button>
-        <button
-          type="button"
-          className="inline-flex w-full items-center justify-center rounded-full border border-border/60 bg-transparent px-6 py-3 text-sm font-semibold text-foreground transition hover:border-border hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsla(var(--color-foreground)/0.5)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))]"
-          data-analytics-event="auth:provider:facebook"
-          disabled={Boolean(isProviderSubmitting)}
-          onClick={() => void handleProviderSignIn("facebook")}
-        >
-          {isProviderSubmitting === "facebook" ? "Connecting to Facebook…" : "Continue with Facebook"}
-        </button>
-        <button
-          type="button"
-          className="inline-flex w-full items-center justify-center rounded-full border border-border/60 bg-transparent px-6 py-3 text-sm font-semibold text-foreground transition hover:border-border hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsla(var(--color-foreground)/0.5)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))]"
-          data-analytics-event="auth:provider:apple"
-          disabled={Boolean(isProviderSubmitting)}
-          onClick={() => void handleProviderSignIn("apple")}
-        >
-          {isProviderSubmitting === "apple" ? "Connecting to Apple…" : "Continue with Apple"}
-        </button>
-        <button
-          type="button"
-          className="inline-flex w-full items-center justify-center rounded-full border border-border/60 bg-transparent px-6 py-3 text-sm font-semibold text-foreground transition hover:border-border hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsla(var(--color-foreground)/0.5)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))]"
-          data-analytics-event="auth:provider:phone"
-          disabled={Boolean(isProviderSubmitting)}
-          onClick={() => void handleProviderSignIn("phone")}
-        >
-          {isProviderSubmitting === "phone" ? "Texting your phone…" : "Continue with phone number"}
-        </button>
-      </div>
-
-      <div className="flex items-center gap-4 text-xs uppercase tracking-[0.3em] text-muted-foreground/70">
-        <span className="h-px flex-1 bg-muted/60" aria-hidden />
-        Or
-        <span className="h-px flex-1 bg-muted/60" aria-hidden />
-      </div>
-
       <form className="space-y-6" method="post" data-analytics-event="auth:submit" onSubmit={handleSubmit}>
         <div className="grid gap-2 text-left">
-          <label className="text-sm font-medium text-foreground/80" htmlFor="email">
+          <label className="text-sm font-medium text-muted-foreground" htmlFor="email">
             Email address
           </label>
           <input
@@ -117,17 +92,20 @@ export function LoginForm() {
             type="email"
             autoComplete="email"
             required
-            className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
+            disabled={isBusy}
+            className="block w-full rounded-xl border border-border bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))] disabled:opacity-70"
             placeholder="you@teamradio.com"
           />
         </div>
 
         <div className="grid gap-2 text-left">
           <div className="flex items-center justify-between">
-            <label className="text-sm font-medium text-foreground/80" htmlFor="password">
+            <label className="text-sm font-medium text-muted-foreground" htmlFor="password">
               Password
             </label>
-            <span className="text-xs font-medium text-accent">Contact ops</span>
+            <Link className="text-sm font-semibold text-accent transition hover:text-accent-muted" href="/forgot-password">
+              Forgot password?
+            </Link>
           </div>
           <input
             id="password"
@@ -135,25 +113,78 @@ export function LoginForm() {
             type="password"
             autoComplete="current-password"
             required
-            className="block w-full rounded-lg border border-border/70 bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
+            disabled={isBusy}
+            aria-invalid={passwordError ? true : undefined}
+            aria-describedby={passwordError ? "password-error" : undefined}
+            className="block w-full rounded-xl border border-border bg-transparent px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))] disabled:opacity-70"
             placeholder="••••••••"
           />
+          {passwordError ? (
+            <p className="text-sm font-medium text-destructive" id="password-error" role="alert">
+              {passwordError}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex items-center justify-between text-sm">
+          <label className="inline-flex items-center gap-2 text-muted-foreground" htmlFor="remember">
+            <input
+              id="remember"
+              name="remember"
+              type="checkbox"
+              disabled={isBusy}
+              className="h-4 w-4 rounded border border-border bg-transparent text-accent focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-[hsl(var(--color-bg))]"
+            />
+            Remember me
+          </label>
+          <span className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Lap ready</span>
         </div>
 
         <button
           type="submit"
-          className="inline-flex w-full items-center justify-center rounded-full bg-[hsl(var(--color-accent))] px-6 py-3 text-sm font-semibold text-background transition hover:bg-[hsl(var(--color-accent-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsla(var(--color-foreground)/0.55)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))] disabled:cursor-not-allowed disabled:opacity-70"
+          className="inline-flex w-full items-center justify-center rounded-full bg-[hsl(var(--color-accent))] px-6 py-3 text-sm font-semibold text-[hsl(var(--color-card))] transition hover:bg-[hsl(var(--color-accent-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsla(var(--color-accent)/0.35)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))] disabled:cursor-not-allowed disabled:opacity-80"
           data-analytics-event="auth:submit:primary"
           disabled={isSubmitting}
         >
           {isSubmitting ? "Signing in…" : "Sign in"}
         </button>
-        {error ? (
-          <p className="text-sm font-medium text-destructive" role="alert">
-            {error}
-          </p>
-        ) : null}
       </form>
+
+      <div className="flex items-center gap-4 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground/80">
+        <span className="h-px flex-1 bg-muted" aria-hidden />
+        Or continue with
+        <span className="h-px flex-1 bg-muted" aria-hidden />
+      </div>
+
+      <div className="space-y-3" aria-label="Social sign in options">
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center rounded-full bg-[hsl(var(--color-accent))] px-6 py-3 text-sm font-semibold text-[hsl(var(--color-card))] transition hover:bg-[hsl(var(--color-accent-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsla(var(--color-accent)/0.35)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))] disabled:cursor-not-allowed disabled:opacity-80"
+          data-analytics-event="auth:provider:google"
+          disabled={isBusy}
+          onClick={() => void handleProviderSignIn("google")}
+        >
+          {isProviderSubmitting === "google" ? providerCopy.google.busy : providerCopy.google.label}
+        </button>
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center rounded-full border border-border bg-card px-6 py-3 text-sm font-semibold text-foreground transition hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))] disabled:cursor-not-allowed disabled:opacity-70"
+          data-analytics-event="auth:provider:apple"
+          disabled={isBusy}
+          onClick={() => void handleProviderSignIn("apple")}
+        >
+          {isProviderSubmitting === "apple" ? providerCopy.apple.busy : providerCopy.apple.label}
+        </button>
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center rounded-full border border-border bg-card px-6 py-3 text-sm font-semibold text-foreground transition hover:border-[hsl(var(--color-accent-2))] hover:text-[hsl(var(--color-accent-2))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--color-accent-2))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--color-bg))] disabled:cursor-not-allowed disabled:opacity-70"
+          data-analytics-event="auth:provider:facebook"
+          disabled={isBusy}
+          onClick={() => void handleProviderSignIn("facebook")}
+        >
+          {isProviderSubmitting === "facebook" ? providerCopy.facebook.busy : providerCopy.facebook.label}
+        </button>
+      </div>
     </Fragment>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,7 @@ const config: Config = {
         border: "hsl(var(--color-card-border) / <alpha-value>)",
         accent: "hsl(var(--color-accent) / <alpha-value>)",
         "accent-muted": "hsl(var(--color-accent-muted) / <alpha-value>)",
+        "accent-2": "hsl(var(--color-accent-2) / <alpha-value>)",
         success: "hsl(var(--color-success) / <alpha-value>)",
         destructive: "hsl(var(--color-destructive) / <alpha-value>)",
       },


### PR DESCRIPTION
## Summary
- refresh the global token palette to the blue-and-mint scheme and surface the mint accent in Tailwind
- rebuild the login layout with the required header, centered card, provider ordering, and footer copy
- update the login form interactions with remember-me support, inline password errors, and refreshed provider buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f6d0f108832188ba600e14227d71