### PR TITLE
Refine page telemetry logging

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 
-import { getLogger } from "@/lib/logging";
-import { trackEvent } from "@/lib/telemetry";
+import { PageViewLogger } from "@/components/page-view-logger";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -27,17 +26,16 @@ const mockMetrics = [
 ];
 
 export default function DashboardPage() {
-  getLogger().info("dashboard.viewed");
-  trackEvent("dashboard.render");
-
   return (
-    <div className="space-y-10">
-      <section className="space-y-2">
-        <h1 className="text-3xl font-semibold">Race control overview</h1>
-        <p className="text-sm text-muted-foreground">
-          Keep tabs on laps, alerts, and coaching notes from practice through mains.
-        </p>
-      </section>
+    <>
+      <PageViewLogger event="dashboard.render" message="dashboard.viewed" />
+      <div className="space-y-10">
+        <section className="space-y-2">
+          <h1 className="text-3xl font-semibold">Race control overview</h1>
+          <p className="text-sm text-muted-foreground">
+            Keep tabs on laps, alerts, and coaching notes from practice through mains.
+          </p>
+        </section>
 
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {mockMetrics.map((metric) => (
@@ -84,6 +82,7 @@ export default function DashboardPage() {
           </div>
         </div>
       </section>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/app/(app)/ops/page.tsx
+++ b/src/app/(app)/ops/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 
-import { getLogger } from "@/lib/logging";
-import { trackEvent } from "@/lib/telemetry";
+import { PageViewLogger } from "@/components/page-view-logger";
 
 export const metadata: Metadata = {
   title: "Operations",
@@ -33,23 +32,22 @@ const statusStyles: Record<"operational" | "degraded" | "outage", string> = {
 };
 
 export default function OpsPage() {
-  getLogger().info("ops.viewed");
-  trackEvent("ops.render");
-
   return (
-    <div className="space-y-10">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold">Operational readiness</h1>
-        <p className="text-sm text-muted-foreground">
-          Instrumented health checks and structured logs keep the pit wall confident.
-        </p>
-      </header>
-      <div className="grid gap-4 lg:grid-cols-2">
-        {checks.map((check) => (
-          <article
-            key={check.title}
-            className="rounded-2xl border border-border/70 bg-background/80 p-5 shadow-card"
-          >
+    <>
+      <PageViewLogger event="ops.render" message="ops.viewed" />
+      <div className="space-y-10">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-semibold">Operational readiness</h1>
+          <p className="text-sm text-muted-foreground">
+            Instrumented health checks and structured logs keep the pit wall confident.
+          </p>
+        </header>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {checks.map((check) => (
+            <article
+              key={check.title}
+              className="rounded-2xl border border-border/70 bg-background/80 p-5 shadow-card"
+            >
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-foreground">{check.title}</h2>
               <span
@@ -60,8 +58,9 @@ export default function OpsPage() {
             </div>
             <p className="mt-3 text-sm text-muted-foreground">{check.description}</p>
           </article>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/app/(app)/timeline/page.tsx
+++ b/src/app/(app)/timeline/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 
-import { withRequestLogger } from "@/lib/logging";
-import { trackEvent } from "@/lib/telemetry";
+import { PageViewLogger } from "@/components/page-view-logger";
 
 export const metadata: Metadata = {
   title: "Timeline",
@@ -36,33 +35,36 @@ const severityStyles: Record<typeof events[number]["severity"], string> = {
 };
 
 export default function TimelinePage() {
-  const logger = withRequestLogger({ route: "timeline" });
-  logger.info("timeline.viewed");
-  trackEvent("timeline.render");
-
   return (
-    <div className="space-y-8">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold">Session timeline</h1>
-        <p className="text-sm text-muted-foreground">
-          Cross-reference telemetry spikes with pit callouts to coach smarter.
-        </p>
-      </header>
-      <ol className="space-y-4">
-        {events.map((event) => (
-          <li key={event.id} className="rounded-2xl border border-border/60 bg-background/80 p-5 shadow-card">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground/80">
-                {event.label}
-              </span>
-              <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.28em] ${severityStyles[event.severity]}`}>
-                {event.severity}
-              </span>
-            </div>
-            <p className="mt-3 text-sm text-foreground">{event.message}</p>
-          </li>
-        ))}
-      </ol>
-    </div>
+    <>
+      <PageViewLogger
+        context={{ route: "timeline" }}
+        event="timeline.render"
+        message="timeline.viewed"
+      />
+      <div className="space-y-8">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-semibold">Session timeline</h1>
+          <p className="text-sm text-muted-foreground">
+            Cross-reference telemetry spikes with pit callouts to coach smarter.
+          </p>
+        </header>
+        <ol className="space-y-4">
+          {events.map((event) => (
+            <li key={event.id} className="rounded-2xl border border-border/60 bg-background/80 p-5 shadow-card">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground/80">
+                  {event.label}
+                </span>
+                <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.28em] ${severityStyles[event.severity]}`}>
+                  {event.severity}
+                </span>
+              </div>
+              <p className="mt-3 text-sm text-foreground">{event.message}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </>
   );
 }

--- a/src/components/page-view-logger.tsx
+++ b/src/components/page-view-logger.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { getLogger, withRequestLogger } from "@/lib/logging";
+import { trackEvent } from "@/lib/telemetry";
+
+type PageViewLoggerProps = {
+  event: string;
+  message: string;
+  context?: Record<string, unknown>;
+};
+
+export function PageViewLogger({ event, message, context }: PageViewLoggerProps) {
+  const hasLogged = useRef(false);
+
+  useEffect(() => {
+    if (hasLogged.current) {
+      return;
+    }
+
+    hasLogged.current = true;
+
+    const logger = context ? withRequestLogger(context) : getLogger();
+    logger.info(message);
+    trackEvent(event);
+  }, [context, event, message]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a client-only PageViewLogger helper that safely records telemetry on mount
- use the helper in dashboard, ops, and timeline pages to avoid duplicate render side-effects

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d3c9be51b88321907a364f5dd0626a