### PR TITLE
Normalize demo email and sanitize auth telemetry

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,47 @@
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function hashIdentifier(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+    hash >>>= 0;
+  }
+
+  return `h${hash.toString(16)}`;
+}
+
+export function redactEmail(email: string): string {
+  const normalized = normalizeEmail(email);
+  const [local, domain] = normalized.split("@");
+
+  if (!domain) {
+    return "redacted";
+  }
+
+  if (local.length <= 2) {
+    const first = local.at(0) ?? "*";
+    return `${first}*@${domain}`;
+  }
+
+  const visible = local.slice(0, 2);
+  const obscured = "*".repeat(local.length - 2);
+  return `${visible}${obscured}@${domain}`;
+}
+
+export function getEmailTelemetry(email: string | null | undefined): {
+  hasEmail: boolean;
+  emailHash?: string;
+} {
+  if (!email) {
+    return { hasEmail: false };
+  }
+
+  const normalized = normalizeEmail(email);
+  return {
+    hasEmail: true,
+    emailHash: hashIdentifier(normalized),
+  };
+}

--- a/web/src/components/auth/LoginScreen.tsx
+++ b/web/src/components/auth/LoginScreen.tsx
@@ -49,11 +49,8 @@ export function LoginScreen({ isLoading, errorMessage, provider, success }: Logi
               disabled={disableForm}
               error={!success ? errorMessage : undefined}
             />
-            <div className="flex items-center justify-between text-sm text-muted">
-              <label className="flex items-center gap-2">
-                <input type="checkbox" name="remember" defaultChecked disabled={disableForm} />
-                <span>Remember me</span>
-              </label>
+            <div className="flex justify-between text-sm text-muted">
+              <span className="uppercase tracking-[0.22em]">Lap ready</span>
               <a className="text-accent" href="/forgot-password">
                 Forgot password?
               </a>


### PR DESCRIPTION
## Summary
- normalize the configured demo credential email before comparison and reuse a trimmed placeholder value
- remove the inert "remember me" checkbox from the login form and supporting UI stub so the screen matches delivered behavior
- hash email identifiers for authentication telemetry and redact values before logging to avoid leaking PII

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4a7ec230883218472c9dde18ef63a