### PR TITLE
Fix ops status typing and limit tsconfig scope

### DIFF
--- a/src/app/(app)/ops/page.tsx
+++ b/src/app/(app)/ops/page.tsx
@@ -7,7 +7,21 @@ export const metadata: Metadata = {
   description: "Operational readiness, health checks, and service-level instrumentation.",
 };
 
-const checks = [
+type CheckStatus = "operational" | "degraded" | "outage";
+
+const statusStyles: Record<CheckStatus, string> = {
+  operational: "bg-success/15 text-success border-success/40",
+  degraded: "bg-warning/15 text-warning border-warning/40",
+  outage: "bg-destructive/15 text-destructive border-destructive/40",
+};
+
+type Check = {
+  title: string;
+  description: string;
+  status: CheckStatus;
+};
+
+const checks: Check[] = [
   {
     title: "Ingest service",
     description: "Webhooks processed under 300ms with no retries in the last hour.",
@@ -24,12 +38,6 @@ const checks = [
     status: "degraded",
   },
 ];
-
-const statusStyles: Record<"operational" | "degraded" | "outage", string> = {
-  operational: "bg-success/15 text-success border-success/40",
-  degraded: "bg-warning/15 text-warning border-warning/40",
-  outage: "bg-destructive/15 text-destructive border-destructive/40",
-};
 
 export default function OpsPage() {
   return (
@@ -48,16 +56,16 @@ export default function OpsPage() {
               key={check.title}
               className="rounded-2xl border border-border/70 bg-background/80 p-5 shadow-card"
             >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-foreground">{check.title}</h2>
-              <span
-                className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] ${statusStyles[check.status]}`}
-              >
-                {check.status}
-              </span>
-            </div>
-            <p className="mt-3 text-sm text-muted-foreground">{check.description}</p>
-          </article>
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-foreground">{check.title}</h2>
+                <span
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] ${statusStyles[check.status]}`}
+                >
+                  {check.status}
+                </span>
+              </div>
+              <p className="mt-3 text-sm text-muted-foreground">{check.description}</p>
+            </article>
           ))}
         </div>
       </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,11 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- define a typed CheckStatus union for the ops dashboard and apply it to the mock checks
- move statusStyles above the data definition and clean up markup indentation
- narrow the TypeScript include globs to src/ so build ignores unrelated example apps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b107ecd483218c9d5b711f509f16