### PR TITLE
Improve telemetry hygiene

### DIFF
--- a/src/components/page-view-logger.tsx
+++ b/src/components/page-view-logger.tsx
@@ -22,8 +22,10 @@ export function PageViewLogger({ event, message, context }: PageViewLoggerProps)
     hasLogged.current = true;
 
     const logger = context ? withRequestLogger(context) : getLogger();
+    const telemetryPayload = { ...(context ?? {}), message };
+
     logger.info(message);
-    trackEvent(event);
+    trackEvent(event, telemetryPayload);
   }, [context, event, message]);
 
   return null;

--- a/src/components/sign-out-button.tsx
+++ b/src/components/sign-out-button.tsx
@@ -2,6 +2,7 @@
 
 import { signOut } from "next-auth/react";
 
+import { getEmailTelemetry } from "@/lib/email";
 import { trackUiEvent } from "@/lib/telemetry";
 
 type Props = {
@@ -10,7 +11,7 @@ type Props = {
 
 export function SignOutButton({ email }: Props) {
   const handleSignOut = async () => {
-    trackUiEvent("auth.signOut", { email });
+    trackUiEvent("auth.signOut", getEmailTelemetry(email));
     await signOut({ callbackUrl: "/login" });
   };
 


### PR DESCRIPTION
## Summary
- include page metadata in page-view telemetry payloads so downstream analytics retain context
- avoid emitting raw email addresses when tracking UI sign-out events by reusing the email telemetry helper

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b3d2f9d88321bcb83ff8325cb448