### PR TITLE
Add dashboard, auth stubs, legal pages, and health endpoint

### DIFF
--- a/web/mdx.d.ts
+++ b/web/mdx.d.ts
@@ -1,0 +1,7 @@
+declare module "*.mdx" {
+  import type { ComponentType } from "react";
+
+  const MDXComponent: ComponentType<Record<string, unknown>>;
+  export default MDXComponent;
+  export const metadata: Record<string, unknown>;
+}

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,9 +1,13 @@
+import createMDX from "@next/mdx";
+
+const withMDX = createMDX();
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
-    typedRoutes: true
-  }
+    typedRoutes: true,
+  },
 };
 
-export default nextConfig;
+export default withMDX(nextConfig);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pacetrace-web",
       "version": "0.1.0",
       "dependencies": {
+        "@next/mdx": "^15.5.4",
         "next": "14.2.5",
         "next-auth": "^4.24.11",
         "react": "^18.3.1",
@@ -1093,7 +1094,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdx": "^2.0.0"
@@ -1134,6 +1135,27 @@
       "license": "MIT",
       "dependencies": {
         "glob": "10.3.10"
+      }
+    },
+    "node_modules/@next/mdx": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.4.tgz",
+      "integrity": "sha512-QUc14KkswCau2/Lul13t13v8QYRiEh3aeyUMUix5mK/Zd8c/J9NQuVvLGhxS7fxGPU+fOcv0GaXqZshkvNaX7A==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.7.0"
+      },
+      "peerDependencies": {
+        "@mdx-js/loader": ">=0.15.0",
+        "@mdx-js/react": ">=0.15.0"
+      },
+      "peerDependenciesMeta": {
+        "@mdx-js/loader": {
+          "optional": true
+        },
+        "@mdx-js/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -2462,7 +2484,7 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2479,14 +2501,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3840,7 +3862,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7857,6 +7879,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --exit-once-uploaded --only-changed --allow-console-errors"
   },
   "dependencies": {
+    "@next/mdx": "^15.5.4",
     "next": "14.2.5",
     "next-auth": "^4.24.11",
     "react": "^18.3.1",

--- a/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,8 @@
 import NextAuth from "next-auth";
+import type { NextAuthOptions } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 
-const handler = NextAuth({
+export const authOptions: NextAuthOptions = {
   providers: [
     Credentials({
       name: "Credentials",
@@ -28,6 +29,8 @@ const handler = NextAuth({
   pages: {
     signIn: "/login",
   },
-});
+};
+
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ ok: true }, { status: 200 });
+}

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+export const metadata: Metadata = {
+  title: "Dashboard — PaceTrace",
+};
+
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login?error=unauthenticated");
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 text-foreground">
+      <h1 className="text-3xl font-semibold">Welcome, {session.user?.email ?? "pace-setter"}</h1>
+      <p className="mt-2 text-sm text-muted">
+        This is your PaceTrace workspace shell. We will hydrate it with live telemetry soon.
+      </p>
+    </main>
+  );
+}

--- a/web/src/app/forgot-password/page.tsx
+++ b/web/src/app/forgot-password/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { AuthCard } from "@/components/auth/AuthCard";
+import { AuthFooter } from "@/components/auth/AuthFooter";
+import { AuthHeader } from "@/components/auth/AuthHeader";
+import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
+
+interface ForgotPasswordPageProps {
+  searchParams?: Record<string, string | string[] | undefined>;
+}
+
+export const metadata: Metadata = {
+  title: "Forgot Password — PaceTrace",
+};
+
+function resolveBoolean(value?: string | string[]): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  return candidate === "true" || candidate === "1";
+}
+
+function resolveString(value?: string | string[]): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function redirectWithSearch(params: Record<string, string | undefined>) {
+  const search = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) {
+      search.set(key, value);
+    }
+  });
+
+  const query = search.toString();
+  redirect(query ? `/forgot-password?${query}` : "/forgot-password");
+}
+
+async function forgotPasswordAction(formData: FormData) {
+  "use server";
+
+  const email = ((formData.get("email") as string | null) ?? "").trim();
+
+  if (!email) {
+    redirectWithSearch({ error: "missingEmail" });
+  }
+
+  // Placeholder: this action only acknowledges the request today.
+  // When email delivery is available, enqueue the reset token send here.
+  redirectWithSearch({ success: "1" });
+}
+
+const FORGOT_PASSWORD_ERROR_MESSAGES: Record<string, string> = {
+  missingEmail: "Enter the email tied to your PaceTrace workspace to continue.",
+  unknown: "We couldn't process that reset attempt. Try again shortly.",
+};
+
+export default function ForgotPasswordPage({ searchParams }: ForgotPasswordPageProps) {
+  const params = searchParams ?? {};
+  const success = resolveBoolean(params.success);
+  const errorKey = resolveString(params.error);
+  const errorMessage = errorKey ? FORGOT_PASSWORD_ERROR_MESSAGES[errorKey] ?? FORGOT_PASSWORD_ERROR_MESSAGES.unknown : undefined;
+
+  return (
+    <div className="flex min-h-screen flex-col items-center bg-background text-foreground">
+      <AuthHeader />
+      <main className="flex w-full flex-1 flex-col items-center px-4">
+        <AuthCard
+          title="Reset password"
+          helper="We'll send you a secure reset link."
+          footerSlot={
+            <span>
+              Remembered it? <a className="text-accent" href="/login">Return to sign in</a>
+            </span>
+          }
+        >
+          <ForgotPasswordForm action={forgotPasswordAction} errorMessage={errorMessage} success={success} />
+        </AuthCard>
+        <AuthFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/src/app/legal/privacy/page.mdx
+++ b/web/src/app/legal/privacy/page.mdx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: "Privacy — PaceTrace",
+};
+
+# Privacy Policy
+
+We are drafting the PaceTrace privacy commitments to match our telemetry safeguards. Expect the full policy shortly.
+
+_Last updated: July 5, 2024._

--- a/web/src/app/legal/terms/page.mdx
+++ b/web/src/app/legal/terms/page.mdx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: "Terms — PaceTrace",
+};
+
+# Terms of Service
+
+These placeholder terms outline the upcoming rules of the PaceTrace track. The full pit wall briefing will arrive soon.
+
+_Last updated: July 5, 2024._

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { AuthCard } from "@/components/auth/AuthCard";
+import { AuthFooter } from "@/components/auth/AuthFooter";
+import { AuthHeader } from "@/components/auth/AuthHeader";
+import { RegisterForm } from "@/components/auth/RegisterForm";
+
+interface RegisterPageProps {
+  searchParams?: Record<string, string | string[] | undefined>;
+}
+
+export const metadata: Metadata = {
+  title: "Register — PaceTrace",
+};
+
+const REGISTER_ERROR_MESSAGES: Record<string, string> = {
+  missingFields: "We need all fields to keep your workspace request on track.",
+  invalidEmail: "That email format looks off. Double-check it before resubmitting.",
+  weakPassword: "Passwords need at least 8 characters to stay race-ready.",
+  unknown: "We couldn't process that request. Please try again.",
+};
+
+function resolveString(value?: string | string[]): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function resolveBoolean(value?: string | string[]): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  return candidate === "true" || candidate === "1";
+}
+
+function redirectWithSearch(params: Record<string, string | undefined>) {
+  const search = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) {
+      search.set(key, value);
+    }
+  });
+
+  const query = search.toString();
+  redirect(query ? `/register?${query}` : "/register");
+}
+
+async function registerAction(formData: FormData) {
+  "use server";
+
+  const email = ((formData.get("email") as string | null) ?? "").trim();
+  const displayName = ((formData.get("displayName") as string | null) ?? "").trim();
+  const password = (formData.get("password") as string | null) ?? "";
+
+  if (!email || !displayName || !password) {
+    redirectWithSearch({ error: "missingFields" });
+  }
+
+  if (!/^.+@.+\..+$/.test(email)) {
+    redirectWithSearch({ error: "invalidEmail" });
+  }
+
+  if (password.length < 8) {
+    redirectWithSearch({ error: "weakPassword" });
+  }
+
+  // Placeholder: this action only validates field shape today.
+  // When we wire up persistence, persist the workspace request and emit onboarding notifications here.
+  redirectWithSearch({ success: "1" });
+}
+
+export default function RegisterPage({ searchParams }: RegisterPageProps) {
+  const params = searchParams ?? {};
+  const success = resolveBoolean(params.success);
+  const errorKey = resolveString(params.error);
+
+  const errorMessage = errorKey ? REGISTER_ERROR_MESSAGES[errorKey] ?? REGISTER_ERROR_MESSAGES.unknown : undefined;
+
+  return (
+    <div className="flex min-h-screen flex-col items-center bg-background text-foreground">
+      <AuthHeader />
+      <main className="flex w-full flex-1 flex-col items-center px-4">
+        <AuthCard
+          title="Create account"
+          helper="Start your PaceTrace workspace."
+          footerSlot={
+            <span>
+              Already a member? <a className="text-accent" href="/login">Sign in</a>
+            </span>
+          }
+        >
+          <RegisterForm action={registerAction} errorMessage={errorMessage} success={success} />
+        </AuthCard>
+        <AuthFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/src/components/auth/ForgotPasswordForm.tsx
+++ b/web/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { FormHTMLAttributes } from "react";
+import { useFormStatus } from "react-dom";
+
+import { ErrorBanner } from "./ErrorBanner";
+import { PrimaryButton } from "./PrimaryButton";
+import { TextInput } from "./TextInput";
+
+interface ForgotPasswordFormProps extends Pick<FormHTMLAttributes<HTMLFormElement>, "action"> {
+  errorMessage?: string;
+  success?: boolean;
+}
+
+export function ForgotPasswordForm({ action, errorMessage, success }: ForgotPasswordFormProps) {
+  return (
+    <form className="space-y-6" aria-label="Reset password form" action={action}>
+      <ForgotPasswordFormContent errorMessage={errorMessage} success={success} />
+    </form>
+  );
+}
+
+function ForgotPasswordFormContent({ errorMessage, success }: { errorMessage?: string; success?: boolean }) {
+  const { pending } = useFormStatus();
+  const disableFields = pending || Boolean(success);
+
+  return (
+    <>
+      <TextInput
+        label="Email"
+        name="email"
+        type="email"
+        autoComplete="email"
+        placeholder="you@pacetrace.app"
+        required
+        disabled={disableFields}
+        error={!success ? errorMessage : undefined}
+      />
+      {success ? (
+        <p
+          role="status"
+          className="rounded-lg border border-accent/30 bg-[color:color-mix(in_srgb,var(--color-accent)_12%,transparent)] px-4 py-3 text-sm text-accent"
+        >
+          If the email exists, a reset link has been sent.
+        </p>
+      ) : null}
+      <ForgotPasswordSubmitButton pending={pending} disabled={disableFields && !pending} />
+    </>
+  );
+}
+
+function ForgotPasswordSubmitButton({ pending, disabled }: { pending: boolean; disabled: boolean }) {
+  return (
+    <PrimaryButton isLoading={pending} disabled={disabled}>
+      Send reset link
+    </PrimaryButton>
+  );
+}

--- a/web/src/components/auth/RegisterForm.tsx
+++ b/web/src/components/auth/RegisterForm.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import type { FormHTMLAttributes } from "react";
+import { useFormStatus } from "react-dom";
+
+import { ErrorBanner } from "./ErrorBanner";
+import { PrimaryButton } from "./PrimaryButton";
+import { TextInput } from "./TextInput";
+
+interface RegisterFormProps extends Pick<FormHTMLAttributes<HTMLFormElement>, "action"> {
+  errorMessage?: string;
+  success?: boolean;
+}
+
+export function RegisterForm({ action, errorMessage, success }: RegisterFormProps) {
+  return (
+    <form className="space-y-6" aria-label="Create account form" action={action}>
+      <RegisterFormContent errorMessage={errorMessage} success={success} />
+    </form>
+  );
+}
+
+function RegisterFormContent({ errorMessage, success }: { errorMessage?: string; success?: boolean }) {
+  const { pending } = useFormStatus();
+  const disableFields = pending || Boolean(success);
+
+  return (
+    <>
+      {errorMessage && !success ? <ErrorBanner message={errorMessage} /> : null}
+      {success ? (
+        <p
+          role="status"
+          className="rounded-lg border border-accent/30 bg-[color:color-mix(in_srgb,var(--color-accent)_12%,transparent)] px-4 py-3 text-sm text-accent"
+        >
+          Account request received — continue to {" "}
+          <a className="underline-offset-4 hover:underline" href="/login">
+            Login
+          </a>
+          .
+        </p>
+      ) : null}
+      <TextInput
+        label="Email"
+        name="email"
+        type="email"
+        autoComplete="email"
+        placeholder="team@pacetrace.app"
+        required
+        disabled={disableFields}
+      />
+      <TextInput
+        label="Display name"
+        name="displayName"
+        autoComplete="name"
+        placeholder="Your team handle"
+        required
+        disabled={disableFields}
+      />
+      <div className="space-y-2">
+        <TextInput
+          label="Password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="Create a password"
+          required
+          disabled={disableFields}
+        />
+        <p className="text-sm text-muted">Use at least 8 characters with a mix of numbers and symbols.</p>
+      </div>
+      <RegisterSubmitButton pending={pending} disabled={disableFields && !pending} />
+    </>
+  );
+}
+
+function RegisterSubmitButton({ pending, disabled }: { pending: boolean; disabled: boolean }) {
+  return (
+    <PrimaryButton isLoading={pending} disabled={disabled}>
+      Request access
+    </PrimaryButton>
+  );
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -38,8 +38,10 @@
   },
   "include": [
     "next-env.d.ts",
+    "mdx.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "**/*.mdx",
     ".next/types/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary
- add a protected dashboard page that guards on the NextAuth session
- add register and forgot-password flows with temporary server actions and shared form components
- enable MDX support for placeholder legal pages and expose a simple health check route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4d58d5950832194278e9310dc26cb