### PR TITLE
Fix web workspace path alias for auth routes

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -23,6 +23,9 @@
     ],
     "baseUrl": ".",
     "paths": {
+      "@/*": [
+        "src/*"
+      ],
       "@/components/*": [
         "src/components/*"
       ],


### PR DESCRIPTION
## Summary
- add a catch-all @/* path alias in web/tsconfig.json so auth imports resolve

## Testing
- npm run lint (from web/)

------
https://chatgpt.com/codex/tasks/task_e_68d4db71b70c8321bc292bdee6c2f73b