### PR TITLE
PaceTrace (web): add /legal/privacy and /legal/terms pages

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,7 +1,3 @@
-import createMDX from "@next/mdx";
-
-const withMDX = createMDX();
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -10,4 +6,4 @@ const nextConfig = {
   },
 };
 
-export default withMDX(nextConfig);
+export default nextConfig;

--- a/web/src/app/legal/privacy/page.mdx
+++ b/web/src/app/legal/privacy/page.mdx
@@ -1,9 +1,0 @@
-export const metadata = {
-  title: "Privacy — PaceTrace",
-};
-
-# Privacy Policy
-
-We are drafting the PaceTrace privacy commitments to match our telemetry safeguards. Expect the full policy shortly.
-
-_Last updated: July 5, 2024._

--- a/web/src/app/legal/privacy/page.tsx
+++ b/web/src/app/legal/privacy/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy — PaceTrace",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="space-y-4 py-10">
+      <h1 className="text-3xl font-semibold tracking-tight">Privacy Policy</h1>
+      <p>
+        We are finalizing the PaceTrace privacy commitments and will publish the
+        full policy soon.
+      </p>
+      <p className="text-sm text-muted-foreground">Last updated: July 5, 2024.</p>
+    </div>
+  );
+}

--- a/web/src/app/legal/terms/page.mdx
+++ b/web/src/app/legal/terms/page.mdx
@@ -1,9 +1,0 @@
-export const metadata = {
-  title: "Terms — PaceTrace",
-};
-
-# Terms of Service
-
-These placeholder terms outline the upcoming rules of the PaceTrace track. The full pit wall briefing will arrive soon.
-
-_Last updated: July 5, 2024._

--- a/web/src/app/legal/terms/page.tsx
+++ b/web/src/app/legal/terms/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms — PaceTrace",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="space-y-4 py-10">
+      <h1 className="text-3xl font-semibold tracking-tight">Terms of Service</h1>
+      <p>
+        These interim terms outline the PaceTrace participation guidelines while
+        we prepare the complete agreement.
+      </p>
+      <p className="text-sm text-muted-foreground">Last updated: July 5, 2024.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the `/legal/privacy` and `/legal/terms` pages with static server components that expose metadata and placeholder copy
- simplify the web Next.js configuration now that MDX is no longer required by removing the unused MDX plugin wrapper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4de3a130083218e3d2be38567fcea