### PR TITLE
Remove social login options from login page

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 
 import { LoginScreen } from "@/components/auth/LoginScreen";
-import type { AuthProvider } from "@/components/auth/ProviderButton";
 
 type LoginPageProps = {
   searchParams?: Record<string, string | string[] | undefined>;
@@ -10,18 +9,6 @@ type LoginPageProps = {
 export const metadata: Metadata = {
   title: "Login — PaceTrace",
 };
-
-const allowedProviders: AuthProvider[] = ["google", "apple", "facebook"];
-
-function resolveProvider(value?: string | string[]): AuthProvider | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  const candidate = Array.isArray(value) ? value[0] : value;
-
-  return allowedProviders.find((provider) => provider === candidate) ?? undefined;
-}
 
 function resolveString(value?: string | string[]): string | undefined {
   if (!value) {
@@ -46,7 +33,6 @@ export default function LoginPage({ searchParams }: LoginPageProps) {
 
   const error = resolveString(params.error);
   const success = resolveBoolean(params.success);
-  const provider = resolveProvider(params.provider);
 
-  return <LoginScreen errorMessage={error} success={success} provider={provider} />;
+  return <LoginScreen errorMessage={error} success={success} />;
 }

--- a/web/src/components/auth/LoginForm.tsx
+++ b/web/src/components/auth/LoginForm.tsx
@@ -4,19 +4,16 @@ import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
 
-import { Divider } from "./Divider";
 import { PrimaryButton } from "./PrimaryButton";
-import { ProviderButton, type AuthProvider } from "./ProviderButton";
 import { TextInput } from "./TextInput";
 
 export interface LoginFormProps {
   isLoading?: boolean;
   errorMessage?: string;
-  provider?: AuthProvider;
   success?: boolean;
 }
 
-export function LoginForm({ isLoading, errorMessage, provider, success }: LoginFormProps) {
+export function LoginForm({ isLoading, errorMessage, success }: LoginFormProps) {
   const searchParams = useSearchParams();
   const [internalError, setInternalError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -61,8 +58,7 @@ export function LoginForm({ isLoading, errorMessage, provider, success }: LoginF
   }, [isLoading, isSubmitting, success]);
 
   const error = success ? undefined : errorMessage ?? internalError ?? undefined;
-  const providerInProgress = provider ?? null;
-  const disableForm = Boolean(success || providerInProgress || busy);
+  const disableForm = Boolean(success || busy);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -125,24 +121,6 @@ export function LoginForm({ isLoading, errorMessage, provider, success }: LoginF
       <PrimaryButton isLoading={busy} disabled={disableForm && !busy}>
         Sign in
       </PrimaryButton>
-      <Divider />
-      <div className="space-y-3">
-        <ProviderButton
-          provider="google"
-          isLoading={provider === "google"}
-          disabled={disableForm && provider !== "google"}
-        />
-        <ProviderButton
-          provider="apple"
-          isLoading={provider === "apple"}
-          disabled={disableForm && provider !== "apple"}
-        />
-        <ProviderButton
-          provider="facebook"
-          isLoading={provider === "facebook"}
-          disabled={disableForm && provider !== "facebook"}
-        />
-      </div>
     </form>
   );
 }

--- a/web/src/components/auth/LoginScreen.tsx
+++ b/web/src/components/auth/LoginScreen.tsx
@@ -2,16 +2,14 @@ import { AuthCard } from "./AuthCard";
 import { AuthFooter } from "./AuthFooter";
 import { AuthHeader } from "./AuthHeader";
 import { LoginForm } from "./LoginForm";
-import type { AuthProvider } from "./ProviderButton";
 
 interface LoginScreenProps {
   isLoading?: boolean;
   errorMessage?: string;
-  provider?: AuthProvider;
   success?: boolean;
 }
 
-export function LoginScreen({ isLoading, errorMessage, provider, success }: LoginScreenProps) {
+export function LoginScreen({ isLoading, errorMessage, success }: LoginScreenProps) {
   return (
     <div className="flex min-h-screen flex-col items-center bg-background text-foreground">
       <AuthHeader />
@@ -25,12 +23,7 @@ export function LoginScreen({ isLoading, errorMessage, provider, success }: Logi
             </span>
           }
         >
-          <LoginForm
-            isLoading={isLoading}
-            errorMessage={errorMessage}
-            provider={provider}
-            success={success}
-          />
+          <LoginForm isLoading={isLoading} errorMessage={errorMessage} success={success} />
         </AuthCard>
         <AuthFooter />
       </main>

--- a/web/src/stories/auth/Login.stories.tsx
+++ b/web/src/stories/auth/Login.stories.tsx
@@ -10,10 +10,6 @@ const meta: Meta<typeof LoginScreen> = {
   argTypes: {
     errorMessage: { control: "text" },
     isLoading: { control: "boolean" },
-    provider: {
-      control: "select",
-      options: ["google", "apple", "facebook", undefined],
-    },
     success: { control: "boolean" },
   },
 };
@@ -37,12 +33,6 @@ export const Loading: Story = {
 export const Error: Story = {
   args: {
     errorMessage: "Incorrect password. Try again.",
-  },
-};
-
-export const ProviderInProgress: Story = {
-  args: {
-    provider: "google",
   },
 };
 


### PR DESCRIPTION
## Summary
- remove OAuth provider fetch and state from the login form
- drop the social sign-in buttons so only credential login remains
- align the design workspace login screen with the credential-only experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d517db8ec08321850ad2efddf0bf03