### PR TITLE
feat(auth): email-driven account approval flow (web/)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,11 @@ EMAIL_FROM="noreply@pacetrace.local"
 SMTP_HOST="127.0.0.1"
 SMTP_PORT="1025"
 SMTP_USER=""
-SMTP_PASS=""
+SMTP_PASSWORD=""
 SMTP_SECURE="false"
 
 APPROVAL_ADMIN_EMAILS="admin@example.com"
 APPROVAL_TOKEN_TTL_HOURS="48"
+# Optional: base URL for links in transactional emails
+APP_BASE_URL="http://localhost:3001"
 # Note: client-exposed vars must be prefixed NEXT_PUBLIC_

--- a/docs/adr/ADR-20240719-account-approvals.md
+++ b/docs/adr/ADR-20240719-account-approvals.md
@@ -1,0 +1,15 @@
+# ADR-20240719: Account approvals
+
+## Status
+Accepted
+
+## Context
+Stakeholder feedback highlighted the need to gate new workspaces until an administrator reviews each request. The existing register form only validated inputs and immediately redirected users without persistence or notifications.
+
+## Decision
+We introduced a Prisma/Postgres data model that records users, approval requests, and approval tokens. Registrations create pending users, approval requests, and paired approve/deny tokens whose URLs are emailed to administrators. Approving activates the account and informs the requester; denying marks it rejected and sends a denial email. NextAuth now blocks sign-in until a user is active.
+
+## Consequences
+- Administrators must maintain `APPROVAL_ADMIN_EMAILS` and SMTP credentials in the environment.
+- The approval email contains fallback logging when SMTP delivery fails, providing manual URLs.
+- Pending users will see “Account pending approval” if they attempt to sign in prematurely.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -30,3 +30,12 @@ PaceTrace ships two authentication implementations that stay in lockstep:
 - Auth flows are captured as dedicated stories under `Auth/` (Login, Register, Forgot) with state coverage for default, loading, error, provider in progress, and success.
 - These stories are the visual contract for Chromatic. Any UI adjustment must update the appropriate story and pass the Chromatic check before merge.
 - Chromatic is configured to block pull requests on unexpected layout or visibility diffs. Approvals require both design and auth-owner sign-off per CODEOWNERS.
+
+## Account approvals
+
+- Registration creates a `User` record in a **pending** state and stores the Argon2id hash of the password.
+- Every registration opens an `ApprovalRequest` and issues paired approval and denial tokens that expire after `APPROVAL_TOKEN_TTL_HOURS` (default 48h).
+- Administrators receive an email with Approve and Deny buttons (`/api/approvals/[token]`). Links also log to the server when SMTP delivery fails.
+- Approving the request sets the user to **ACTIVE**, records the admin IP address and timestamp, cleans up outstanding tokens, and emails the requester.
+- Denying the request marks the user **REJECTED**, records metadata, removes tokens, and notifies the requester.
+- NextAuth blocks sign-in for any account whose status is not **ACTIVE**, returning an `Account pending approval` error.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,10 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@next/mdx": "^15.5.4",
+        "@prisma/client": "^6.16.2",
+        "argon2": "^0.44.0",
         "next": "14.2.5",
         "next-auth": "^4.24.11",
+        "nodemailer": "^6.10.1",
+        "prisma": "^6.16.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@storybook/addon-a11y": "^8.1.10",
@@ -402,6 +407,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.10",
@@ -1359,6 +1370,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1368,6 +1388,85 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.2.tgz",
+      "integrity": "sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.2.tgz",
+      "integrity": "sha512-mKXSUrcqXj0LXWPmJsK2s3p9PN+aoAbyMx7m5E1v1FufofR1ZpPoIArjjzOIm+bJRLLvYftoNYLx1tbHgF9/yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.16.12",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.2.tgz",
+      "integrity": "sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.2.tgz",
+      "integrity": "sha512-7yf3AjfPUgsg/l7JSu1iEhsmZZ/YE00yURPjTikqm2z4btM0bCl2coFtTGfeSOWbQMmq45Jab+53yGUIAT1sjA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.16.2",
+        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+        "@prisma/fetch-engine": "6.16.2",
+        "@prisma/get-platform": "6.16.2"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43.tgz",
+      "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.2.tgz",
+      "integrity": "sha512-wPnZ8DMRqpgzye758ZvfAMiNJRuYpz+rhgEBZi60ZqDIgOU2694oJxiuu3GKFeYeR/hXxso4/2oBC243t/whxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.16.2",
+        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+        "@prisma/get-platform": "6.16.2"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.2.tgz",
+      "integrity": "sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.16.2"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1740,6 +1839,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
@@ -3150,6 +3255,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3578,6 +3699,62 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3774,6 +3951,15 @@
         }
       }
     },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3807,6 +3993,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3823,11 +4024,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3961,6 +4178,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4007,6 +4233,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4016,6 +4248,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -4064,6 +4302,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4086,6 +4336,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/effect": {
+      "version": "3.16.12",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
+      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.223",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.223.tgz",
@@ -4099,6 +4359,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -4862,6 +5131,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5176,6 +5473,23 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob": {
@@ -5986,7 +6300,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -6024,6 +6337,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
+      "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
@@ -6566,12 +6888,47 @@
         }
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6591,6 +6948,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nypm": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
+      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.2",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.10.0"
       }
     },
     "node_modules/oauth": {
@@ -6731,6 +7107,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
     },
     "node_modules/oidc-token-hash": {
       "version": "5.1.1",
@@ -6916,7 +7298,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6963,6 +7344,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/pathval": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
@@ -6972,6 +7359,12 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7010,6 +7403,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/polished": {
@@ -7221,6 +7625,31 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prisma": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.2.tgz",
+      "integrity": "sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.16.2",
+        "@prisma/engines": "6.16.2"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -7260,6 +7689,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7280,6 +7725,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -7763,7 +8218,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7776,7 +8230,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8463,6 +8916,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8703,7 +9162,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9365,7 +9824,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9624,6 +10082,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -13,10 +13,15 @@
   },
   "dependencies": {
     "@next/mdx": "^15.5.4",
+    "@prisma/client": "^6.16.2",
+    "argon2": "^0.44.0",
     "next": "14.2.5",
     "next-auth": "^4.24.11",
+    "nodemailer": "^6.10.1",
+    "prisma": "^6.16.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^8.1.10",

--- a/web/prisma/migrations/20240719_account_approvals/migration.sql
+++ b/web/prisma/migrations/20240719_account_approvals/migration.sql
@@ -1,0 +1,55 @@
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('PENDING', 'ACTIVE', 'REJECTED');
+
+-- CreateEnum
+CREATE TYPE "ApprovalAction" AS ENUM ('APPROVE', 'DENY');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "passwordHash" TEXT,
+    "status" "UserStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApprovalRequest" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "decidedAt" TIMESTAMP(3),
+    "decision" "ApprovalAction",
+    "decidedBy" TEXT,
+    CONSTRAINT "ApprovalRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApprovalToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "action" "ApprovalAction" NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ApprovalToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApprovalRequest_userId_key" ON "ApprovalRequest"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApprovalToken_token_key" ON "ApprovalToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "ApprovalRequest" ADD CONSTRAINT "ApprovalRequest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApprovalToken" ADD CONSTRAINT "ApprovalToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/web/prisma/migrations/migration_lock.toml
+++ b/web/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -1,0 +1,52 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserStatus {
+  PENDING
+  ACTIVE
+  REJECTED
+}
+
+enum ApprovalAction {
+  APPROVE
+  DENY
+}
+
+model User {
+  id           String          @id @default(cuid())
+  email        String          @unique
+  name         String?
+  passwordHash String?
+  status       UserStatus      @default(PENDING)
+  createdAt    DateTime        @default(now())
+  updatedAt    DateTime        @updatedAt
+  approvalRequest ApprovalRequest?
+  approvalTokens  ApprovalToken[]
+}
+
+model ApprovalRequest {
+  id        String          @id @default(cuid())
+  userId    String          @unique
+  reason    String?
+  createdAt DateTime        @default(now())
+  decidedAt DateTime?
+  decision  ApprovalAction?
+  decidedBy String?
+  user      User            @relation(fields: [userId], references: [id])
+}
+
+model ApprovalToken {
+  id        String         @id @default(cuid())
+  userId    String
+  token     String         @unique
+  action    ApprovalAction
+  expiresAt DateTime
+  createdAt DateTime       @default(now())
+  user      User           @relation(fields: [userId], references: [id])
+}

--- a/web/src/app/api/approvals/[token]/route.ts
+++ b/web/src/app/api/approvals/[token]/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/server/prisma";
+import { sendUserApproved, sendUserDenied } from "@/server/mailer";
+
+function htmlResponse(body: string, status = 200) {
+  return new NextResponse(
+    `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><title>PaceTrace Approvals</title></head><body style="font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;padding:32px;max-width:480px;margin:0 auto;line-height:1.6;">${body}</body></html>`,
+    {
+      status,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+      },
+    },
+  );
+}
+
+function resolveDecisionIp(request: Request) {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0]?.trim() ?? "unknown";
+  }
+
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) {
+    return realIp;
+  }
+
+  return (request as unknown as { ip?: string | null }).ip ?? "unknown";
+}
+
+export async function GET(request: Request, { params }: { params: { token: string } }) {
+  const { token } = params;
+
+  if (!token) {
+    return htmlResponse("<h1>Invalid request</h1><p>Missing approval token.</p>", 400);
+  }
+
+  const approvalToken = await prisma.approvalToken.findUnique({
+    where: { token },
+    include: { user: true },
+  });
+
+  if (!approvalToken) {
+    return htmlResponse("<h1>Invalid token</h1><p>This approval link is no longer valid.</p>", 404);
+  }
+
+  if (approvalToken.expiresAt.getTime() < Date.now()) {
+    return htmlResponse("<h1>Expired link</h1><p>This approval link has expired.</p>", 410);
+  }
+
+  const approvalRequest = await prisma.approvalRequest.findUnique({
+    where: { userId: approvalToken.userId },
+  });
+
+  if (!approvalRequest) {
+    return htmlResponse("<h1>Missing request</h1><p>The approval request could not be found.</p>", 404);
+  }
+
+  if (approvalRequest.decision) {
+    const label = approvalRequest.decision === "APPROVE" ? "approved" : "denied";
+    return htmlResponse(`<h1>Already ${label}</h1><p>This request was already ${label}.</p>`);
+  }
+
+  const decisionIp = resolveDecisionIp(request);
+
+  try {
+    if (approvalToken.action === "APPROVE") {
+      const result = await prisma.$transaction(async (tx) => {
+        const updatedUser = await tx.user.update({
+          where: { id: approvalToken.userId },
+          data: { status: "ACTIVE" },
+        });
+
+        await tx.approvalRequest.update({
+          where: { userId: approvalToken.userId },
+          data: {
+            decision: "APPROVE",
+            decidedAt: new Date(),
+            decidedBy: decisionIp,
+          },
+        });
+
+        await tx.approvalToken.deleteMany({ where: { userId: approvalToken.userId } });
+
+        return updatedUser;
+      });
+
+      try {
+        await sendUserApproved(result);
+      } catch (error) {
+        console.error("[approvals] Failed to notify approved user", error);
+      }
+
+      return htmlResponse("<h1>Approved</h1><p>The requester has been notified they can sign in.</p>");
+    }
+
+    if (approvalToken.action === "DENY") {
+      const result = await prisma.$transaction(async (tx) => {
+        const updatedUser = await tx.user.update({
+          where: { id: approvalToken.userId },
+          data: { status: "REJECTED" },
+        });
+
+        await tx.approvalRequest.update({
+          where: { userId: approvalToken.userId },
+          data: {
+            decision: "DENY",
+            decidedAt: new Date(),
+            decidedBy: decisionIp,
+          },
+        });
+
+        await tx.approvalToken.deleteMany({ where: { userId: approvalToken.userId } });
+
+        return updatedUser;
+      });
+
+      try {
+        await sendUserDenied(result);
+      } catch (error) {
+        console.error("[approvals] Failed to notify denied user", error);
+      }
+
+      return htmlResponse("<h1>Denied</h1><p>The requester has been notified of the decision.</p>");
+    }
+
+    return htmlResponse("<h1>Unknown action</h1><p>This token could not be processed.</p>", 400);
+  } catch (error) {
+    console.error("[approvals] Failed to process token", error);
+    return htmlResponse("<h1>Server error</h1><p>We couldn't record this decision. Try again.</p>", 500);
+  }
+}

--- a/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,26 @@
 import NextAuth from "next-auth";
 import type { NextAuthOptions } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
+import argon2 from "argon2";
+
+import { prisma } from "@/server/prisma";
+
+interface AuthorizedUser {
+  id: string;
+  email: string;
+  name?: string | null;
+  status: string;
+}
+
+function isAuthorizedUser(value: unknown): value is AuthorizedUser {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return typeof candidate.id === "string" && typeof candidate.email === "string" && typeof candidate.status === "string";
+}
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -10,19 +30,60 @@ export const authOptions: NextAuthOptions = {
         email: { label: "Email", type: "email" },
         password: { label: "Password", type: "password" },
       },
-      authorize(credentials) {
-        if (credentials?.email === "driver@pacetrace.app" && credentials?.password === "pitlane") {
-          return {
-            id: "demo-user",
-            email: credentials.email,
-            name: "Race Strategist",
-          };
+      async authorize(credentials) {
+        const email = credentials?.email;
+        const password = credentials?.password;
+
+        if (!email || !password) {
+          return null;
         }
 
-        return null;
+        const user = await prisma.user.findUnique({ where: { email } });
+
+        if (!user || !user.passwordHash) {
+          return null;
+        }
+
+        const isValid = await argon2.verify(user.passwordHash, password);
+
+        if (!isValid) {
+          return null;
+        }
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          status: user.status,
+        } satisfies AuthorizedUser;
       },
     }),
   ],
+  callbacks: {
+    async signIn({ user }) {
+      if (isAuthorizedUser(user) && user.status !== "ACTIVE") {
+        throw new Error("Account pending approval");
+      }
+
+      return true;
+    },
+    async jwt({ token, user }) {
+      if (isAuthorizedUser(user)) {
+        (token as Record<string, unknown>).userStatus = user.status;
+      }
+
+      return token;
+    },
+    async session({ session, token }) {
+      const status = (token as Record<string, unknown>).userStatus;
+
+      if (session.user && typeof status === "string") {
+        (session.user as Record<string, unknown>).status = status;
+      }
+
+      return session;
+    },
+  },
   session: {
     strategy: "jwt",
   },

--- a/web/src/app/api/register/route.ts
+++ b/web/src/app/api/register/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import argon2 from "argon2";
+import crypto from "node:crypto";
+import { z } from "zod";
+
+import { prisma } from "@/server/prisma";
+import { sendAdminApprovalRequest } from "@/server/mailer";
+
+const registerSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+  password: z.string().min(8),
+});
+
+function resolveTokenTtlMs() {
+  const raw = process.env.APPROVAL_TOKEN_TTL_HOURS;
+  const fallback = 48;
+
+  if (!raw) {
+    return fallback * 60 * 60 * 1000;
+  }
+
+  const hours = Number(raw);
+
+  if (!Number.isFinite(hours) || hours <= 0) {
+    return fallback * 60 * 60 * 1000;
+  }
+
+  return hours * 60 * 60 * 1000;
+}
+
+function buildDecisionUrl(requestUrl: string, token: string) {
+  const url = new URL(requestUrl);
+  url.pathname = `/api/approvals/${token}`;
+  url.search = "";
+
+  return url.toString();
+}
+
+interface PrismaKnownError {
+  code?: string;
+  meta?: Record<string, unknown>;
+}
+
+function isUniqueConstraintError(error: unknown): error is PrismaKnownError {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const candidate = error as PrismaKnownError;
+
+  return candidate.code === "P2002";
+}
+
+export async function POST(request: Request) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: "invalidJson" }, { status: 400 });
+  }
+
+  const parseResult = registerSchema.safeParse(payload);
+
+  if (!parseResult.success) {
+    return NextResponse.json({ ok: false, error: "invalidInput" }, { status: 400 });
+  }
+
+  const { email, name, password } = parseResult.data;
+
+  try {
+    const { user, approveToken, denyToken } = await prisma.$transaction(async (tx) => {
+      const passwordHash = await argon2.hash(password, { type: argon2.argon2id });
+
+      const createdUser = await tx.user.create({
+        data: {
+          email,
+          name,
+          passwordHash,
+          status: "PENDING",
+        },
+      });
+
+      await tx.approvalRequest.create({
+        data: {
+          userId: createdUser.id,
+        },
+      });
+
+      const expiresAt = new Date(Date.now() + resolveTokenTtlMs());
+
+      const approveTokenValue = crypto.randomBytes(32).toString("hex");
+      const denyTokenValue = crypto.randomBytes(32).toString("hex");
+
+      const [approveTokenRecord, denyTokenRecord] = await Promise.all([
+        tx.approvalToken.create({
+          data: {
+            userId: createdUser.id,
+            token: approveTokenValue,
+            action: "APPROVE",
+            expiresAt,
+          },
+        }),
+        tx.approvalToken.create({
+          data: {
+            userId: createdUser.id,
+            token: denyTokenValue,
+            action: "DENY",
+            expiresAt,
+          },
+        }),
+      ]);
+
+      return {
+        user: createdUser,
+        approveToken: approveTokenRecord.token,
+        denyToken: denyTokenRecord.token,
+      };
+    });
+
+    const approveUrl = buildDecisionUrl(request.url, approveToken);
+    const denyUrl = buildDecisionUrl(request.url, denyToken);
+
+    try {
+      await sendAdminApprovalRequest(user, approveUrl, denyUrl);
+    } catch (error) {
+      console.error("[register] Failed to send approval email", error);
+      console.info("[register] Approve URL", approveUrl);
+      console.info("[register] Deny URL", denyUrl);
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return NextResponse.json({ ok: false, error: "emailInUse" }, { status: 409 });
+    }
+
+    console.error("[register] Failed to register user", error);
+
+    return NextResponse.json({ ok: false, error: "serverError" }, { status: 500 });
+  }
+}

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -1,88 +1,15 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 
 import { AuthCard } from "@/components/auth/AuthCard";
 import { AuthFooter } from "@/components/auth/AuthFooter";
 import { AuthHeader } from "@/components/auth/AuthHeader";
 import { RegisterForm } from "@/components/auth/RegisterForm";
 
-interface RegisterPageProps {
-  searchParams?: Record<string, string | string[] | undefined>;
-}
-
 export const metadata: Metadata = {
   title: "Register — PaceTrace",
 };
 
-const REGISTER_ERROR_MESSAGES: Record<string, string> = {
-  missingFields: "We need all fields to keep your workspace request on track.",
-  invalidEmail: "That email format looks off. Double-check it before resubmitting.",
-  weakPassword: "Passwords need at least 8 characters to stay race-ready.",
-  unknown: "We couldn't process that request. Please try again.",
-};
-
-function resolveString(value?: string | string[]): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  return Array.isArray(value) ? value[0] : value;
-}
-
-function resolveBoolean(value?: string | string[]): boolean {
-  if (!value) {
-    return false;
-  }
-
-  const candidate = Array.isArray(value) ? value[0] : value;
-
-  return candidate === "true" || candidate === "1";
-}
-
-function redirectWithSearch(params: Record<string, string | undefined>) {
-  const search = new URLSearchParams();
-
-  Object.entries(params).forEach(([key, value]) => {
-    if (value) {
-      search.set(key, value);
-    }
-  });
-
-  const query = search.toString();
-  redirect(query ? `/register?${query}` : "/register");
-}
-
-async function registerAction(formData: FormData) {
-  "use server";
-
-  const email = ((formData.get("email") as string | null) ?? "").trim();
-  const displayName = ((formData.get("displayName") as string | null) ?? "").trim();
-  const password = (formData.get("password") as string | null) ?? "";
-
-  if (!email || !displayName || !password) {
-    redirectWithSearch({ error: "missingFields" });
-  }
-
-  if (!/^.+@.+\..+$/.test(email)) {
-    redirectWithSearch({ error: "invalidEmail" });
-  }
-
-  if (password.length < 8) {
-    redirectWithSearch({ error: "weakPassword" });
-  }
-
-  // Placeholder: this action only validates field shape today.
-  // When we wire up persistence, persist the workspace request and emit onboarding notifications here.
-  redirectWithSearch({ success: "1" });
-}
-
-export default function RegisterPage({ searchParams }: RegisterPageProps) {
-  const params = searchParams ?? {};
-  const success = resolveBoolean(params.success);
-  const errorKey = resolveString(params.error);
-
-  const errorMessage = errorKey ? REGISTER_ERROR_MESSAGES[errorKey] ?? REGISTER_ERROR_MESSAGES.unknown : undefined;
-
+export default function RegisterPage() {
   return (
     <div className="flex min-h-screen flex-col items-center bg-background text-foreground">
       <AuthHeader />
@@ -96,7 +23,7 @@ export default function RegisterPage({ searchParams }: RegisterPageProps) {
             </span>
           }
         >
-          <RegisterForm action={registerAction} errorMessage={errorMessage} success={success} />
+          <RegisterForm />
         </AuthCard>
         <AuthFooter />
       </main>

--- a/web/src/server/mailer.ts
+++ b/web/src/server/mailer.ts
@@ -1,0 +1,140 @@
+import nodemailer from "nodemailer";
+
+interface MailerUser {
+  email: string;
+  name?: string | null;
+}
+
+function resolveEmailFrom() {
+  const from = process.env.EMAIL_FROM;
+
+  if (!from) {
+    throw new Error("EMAIL_FROM is not configured");
+  }
+
+  return from;
+}
+
+function resolveAdminRecipients(): string[] {
+  const raw = process.env.APPROVAL_ADMIN_EMAILS ?? "";
+
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function isConsoleFallback() {
+  const host = process.env.SMTP_HOST;
+  const user = process.env.SMTP_USER;
+
+  return host === "127.0.0.1" && !user;
+}
+
+function createTransport() {
+  const host = process.env.SMTP_HOST;
+  const port = process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : undefined;
+  const user = process.env.SMTP_USER;
+  const password = process.env.SMTP_PASSWORD;
+  const secure = process.env.SMTP_SECURE === "true";
+
+  if (!host) {
+    throw new Error("SMTP_HOST is not configured");
+  }
+
+  if (!port) {
+    throw new Error("SMTP_PORT is not configured");
+  }
+
+  if (!user || !password) {
+    return nodemailer.createTransport({
+      host,
+      port,
+      secure,
+    });
+  }
+
+  return nodemailer.createTransport({
+    host,
+    port,
+    secure,
+    auth: {
+      user,
+      pass: password,
+    },
+  });
+}
+
+async function deliverMail(message: nodemailer.SendMailOptions) {
+  const finalMessage = {
+    ...message,
+    from: resolveEmailFrom(),
+  } satisfies nodemailer.SendMailOptions;
+
+  if (isConsoleFallback()) {
+    console.log("[mailer:fallback]", finalMessage);
+    return;
+  }
+
+  const transporter = createTransport();
+
+  await transporter.sendMail(finalMessage);
+}
+
+export async function sendAdminApprovalRequest(user: MailerUser, approveUrl: string, denyUrl: string) {
+  const recipients = resolveAdminRecipients();
+
+  if (recipients.length === 0) {
+    console.warn("[mailer] No admin recipients configured for approval workflow");
+    return;
+  }
+
+  const name = user.name ? `${user.name} <${user.email}>` : user.email;
+  const subject = `New PaceTrace account request: ${name}`;
+
+  const html = `
+    <p>${name} requested access to PaceTrace.</p>
+    <p>
+      <a href="${approveUrl}" style="display:inline-block;padding:8px 16px;margin-right:8px;background:#16a34a;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Approve</a>
+      <a href="${denyUrl}" style="display:inline-block;padding:8px 16px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Deny</a>
+    </p>
+    <p>If the buttons do not work, copy and paste these URLs:</p>
+    <p>Approve: <a href="${approveUrl}">${approveUrl}</a></p>
+    <p>Deny: <a href="${denyUrl}">${denyUrl}</a></p>
+  `;
+
+  await deliverMail({
+    to: recipients,
+    subject,
+    html,
+  });
+}
+
+export async function sendUserApproved(user: MailerUser) {
+  const baseUrl = process.env.APP_BASE_URL ?? "";
+  const loginUrl = baseUrl ? `${baseUrl.replace(/\/$/, "")}/login` : "https://pacetrace.app/login";
+
+  const html = `
+    <p>You're cleared for the grid.</p>
+    <p>Your PaceTrace account has been approved. You can sign in at <a href="${loginUrl}">${loginUrl}</a>.</p>
+  `;
+
+  await deliverMail({
+    to: user.email,
+    subject: "PaceTrace access approved",
+    html,
+  });
+}
+
+export async function sendUserDenied(user: MailerUser) {
+  const html = `
+    <p>Thanks for your interest in PaceTrace.</p>
+    <p>We weren't able to approve your account request at this time.</p>
+  `;
+
+  await deliverMail({
+    to: user.email,
+    subject: "PaceTrace access request",
+    html,
+  });
+}

--- a/web/src/server/prisma.ts
+++ b/web/src/server/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
## Summary
- add Prisma models and migrations for user approvals in the web workspace
- implement registration and approval APIs with email notifications and NextAuth gating
- wire UI, mailer utilities, and docs to describe the new approval flow

## Testing
- npm run lint

## Manual verification
1. Submit the register form and confirm `{ ok: true }` response from `/api/register`.
2. Open the approve/deny URLs emailed (or logged) to admins and exercise both flows.
3. Sign in with the approved account; verify denied accounts are blocked with `Account pending approval`.


------
https://chatgpt.com/codex/tasks/task_e_68d538e2a4348321adb2cb51822a834b