### PR TITLE
Move forgot password link to login form footer

### DIFF
--- a/src/app/login/sign-in-form.tsx
+++ b/src/app/login/sign-in-form.tsx
@@ -105,14 +105,9 @@ export function LoginForm() {
         </div>
 
         <div className="grid gap-2 text-left">
-          <div className="flex items-center justify-between">
-            <label className="text-sm font-medium text-muted-foreground" htmlFor="password">
-              Password
-            </label>
-            <Link className="text-sm font-semibold text-accent transition hover:text-accent-muted" href="/forgot-password">
-              Forgot password?
-            </Link>
-          </div>
+          <label className="text-sm font-medium text-muted-foreground" htmlFor="password">
+            Password
+          </label>
           <input
             id="password"
             name="password"
@@ -132,8 +127,10 @@ export function LoginForm() {
           ) : null}
         </div>
 
-        <div className="flex justify-end text-sm">
-          <span className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Lap ready</span>
+        <div className="flex justify-end">
+          <Link className="text-sm font-semibold text-accent transition hover:text-accent-muted" href="/forgot-password">
+            Forgot password?
+          </Link>
         </div>
 
         <button

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -107,9 +107,8 @@ export function LoginForm({ isLoading, errorMessage, success }: LoginFormProps) 
         disabled={disableForm}
         error={error}
       />
-      <div className="flex justify-between text-sm text-muted">
-        <span className="uppercase tracking-[0.22em]">Lap ready</span>
-        <a className="text-accent" href="/forgot-password">
+      <div className="flex justify-end text-sm">
+        <a className="text-accent transition hover:text-accent-muted" href="/forgot-password">
           Forgot password?
         </a>
       </div>


### PR DESCRIPTION
## Summary
- remove the "Lap ready" tagline from the login form UI
- relocate the "Forgot password?" link to the bottom of the login card in both app and shared forms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d78f8c621c8321911c2e3945caf304